### PR TITLE
chore: update hunt registry — bounty scout [2026-04-13]

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -1,7 +1,8 @@
-# SecBot Hunt Registry — Diagnostic Run #1
-# Created: 2026-03-22
-# Purpose: First real bounty hunt — 5 carefully selected targets
-# Strategy: low competition + web app depth + SecBot strengths
+# SecBot Hunt Registry
+# Last updated: 2026-04-13 (Bounty Scout cycle)
+# Strategy: Indonesian/SEA home advantage + small EU SaaS + open-source targets
+
+# ── ACTIVE PROGRAMS ────────────────────────────────────────────────────────────
 
 - name: kredivo
   platform: other
@@ -9,6 +10,7 @@
   profile: stealth
   schedule: weekly
   enabled: true
+  notes: "Indonesian fintech BNPL (RedStorm). Low bounties (~$190 critical) but home advantage."
 
 - name: anytask
   platform: bugcrowd
@@ -16,6 +18,7 @@
   profile: stealth
   schedule: weekly
   enabled: true
+  notes: "Freelancer marketplace. Staging domain in scope. $250-$5,000."
 
 - name: moneybird
   platform: hackerone
@@ -23,6 +26,7 @@
   profile: stealth
   schedule: weekly
   enabled: true
+  notes: "Dutch accounting SaaS. Ruby on Rails. ~50-100 employees. $100-$3,000 est."
 
 - name: openproject
   platform: other
@@ -30,10 +34,61 @@
   profile: stealth
   schedule: weekly
   enabled: true
+  notes: "Open-source project management (Rails + Angular). YesWeHack. EUR 100-5,000."
+
+# ── NEW PROGRAMS (added 2026-04-13) ────────────────────────────────────────────
+
+- name: discourse
+  platform: hackerone
+  scope_file: scopes/discourse.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  notes: >
+    Ruby on Rails forum software. Public test instance (try.discourse.org) explicitly in scope.
+    Excellent payout history — paid $163K+ in one year, avg ~$2,862/report.
+    $256/$512/$1,024/$2,048+ by severity. No automated ban. Small company ~100 employees.
+
+- name: gojek
+  platform: other
+  scope_file: scopes/gojek.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  notes: >
+    Indonesian super app. YesWeHack bounty program (yeswehack.com/programs/gojek-bug-bounty-program).
+    Fresh program July 2025 — low competition. $50-$5,000. Large company but strong home advantage.
+    Raw scanner output disallowed as reports; AI-validated findings fine.
+
+- name: goto-financial
+  platform: other
+  scope_file: scopes/goto-financial.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  notes: >
+    Indonesian fintech — GoPay, GoPayLater. YesWeHack fresh program (July 2025).
+    Higher ceiling than Gojek: $50-$7,000. Rich attack surface: payment APIs, merchant auth, IDOR.
+
+- name: dana
+  platform: other
+  scope_file: scopes/dana.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  notes: >
+    Indonesian digital wallet (YesWeHack). Mature program: 191 reports, <3 days first response.
+    $0-$3,000 + $2,000 face-verification bypass bonus. Rate limiting required — stealth only.
+
+# ── DISABLED PROGRAMS ──────────────────────────────────────────────────────────
 
 - name: calcom
   platform: hackerone
   scope_file: scopes/calcom.txt
   profile: stealth
   schedule: weekly
-  enabled: true
+  enabled: false
+  notes: >
+    DISABLED 2026-04-13: No monetary bounties (VDP only via GitHub). Explicitly bans automated
+    scanners. XSS/CSRF/clickjacking all excluded. Scope file had incorrect *.companyhub.com entry
+    (CompanyHub is a separate company). Not a viable SecBot target.

--- a/scopes/calcom.txt
+++ b/scopes/calcom.txt
@@ -1,11 +1,22 @@
 # Program: Cal.com
-# Platform: HackerOne
-# Bounty: $100 - $3,000 (estimated)
-# Notes: Open-source scheduling (Next.js/TypeScript), code on GitHub, small startup
+# Platform: GitHub Security Advisories (NOT HackerOne — previous entry was incorrect)
+# Bounty: NONE — this is a VDP (Vulnerability Disclosure Program) only
+# Status: DISABLED — removed from active hunt registry 2026-04-13
+# Reason: (1) No monetary rewards paid.
+#         (2) Explicitly bans automated scanners: "Do not run automated scanners on our
+#             infrastructure or dashboard." (cal.com/security)
+#         (3) XSS, CSRF, and clickjacking are all out of scope.
+#         (4) *.companyhub.com entry below was an error — CompanyHub is a separate CRM company.
+# Report via: https://github.com/calcom/cal.com/security/advisories
 
 In Scope
 app.cal.com
-*.companyhub.com
 
 Out of Scope
-- cal.com (marketing site only, not the app)
+- Automated scanning of any kind (explicitly prohibited)
+- XSS (out of scope per program policy)
+- CSRF (out of scope per program policy)
+- Clickjacking (out of scope per program policy)
+- Physical access attacks
+- DoS attacks
+- DNS / email security issues

--- a/scopes/dana.txt
+++ b/scopes/dana.txt
@@ -1,0 +1,26 @@
+# Program: DANA Indonesia
+# Platform: YesWeHack (https://yeswehack.com/programs/dana-bug-bounty-program)
+# Bounty: $0 (Low) - $3,000 (Critical) + $2,000 bonus for face-verification login bypass
+# Notes: Indonesian digital wallet / e-money platform. ~1,000 employees.
+#        Mature program — 191 reports, first response <3 days, last updated Feb 2025.
+#        Holds 4 Bank Indonesia licenses (e-money, digital wallet, money transfer, liquidity).
+#        Indonesian home advantage — local knowledge of payment flows and QRIS ecosystem.
+# Automated tools: Rate limiting is required — "limit yourself about requests per second."
+#                  Use stealth profile (Gaussian delay, max 10 concurrent). Do not hammer APIs.
+# Best attack surface: login/auth flows (face verification!), merchant dashboard IDOR,
+#                      payment API auth bypass, CORS on api subdomains, SSRF in payment flows.
+# WARNING: Do NOT modify, leak, or destroy any user data — immediate program ban.
+
+In Scope
+dana.id
+www.dana.id
+dashboard.dana.id
+*.dana.id
+
+Out of Scope
+- Social engineering and phishing attacks
+- Denial of service / DDoS attacks
+- Tests that cause service degradation or interruption
+- Data manipulation, leakage, or destruction of any user data
+- Vulnerability disclosure without prior written authorization
+- Account squatting activities

--- a/scopes/discourse.txt
+++ b/scopes/discourse.txt
@@ -1,0 +1,22 @@
+# Program: Discourse
+# Platform: HackerOne (https://hackerone.com/discourse)
+# Bounty: $256 (Low) / $512 (Medium) / $1,024 (High) / $2,048+ (Critical)
+# Notes: Ruby on Rails open-source forum software. Public test instance explicitly in scope.
+#        Very active program — paid $163K+ in a single year (avg ~$2,862/report).
+#        Company size: ~100 employees. Small, responsive security team (<1hr avg response).
+# Automated tools: No explicit ban. Policy emphasizes "good faith effort" — avoid DoS/flooding.
+#                  SecBot stealth profile is fine. Do NOT submit raw scanner output reports.
+#                  Each report must include step-by-step reproduction + PoC.
+# 90-day disclosure embargo after fix release.
+
+In Scope
+try.discourse.org
+
+Out of Scope
+- Any Discourse installation other than try.discourse.org (e.g., meta.discourse.org, hosted forums)
+- SSRF to external resources (Discourse deliberately permits this by design)
+- Admin-initiated XSS or denial-of-service (requires admin privileges to trigger)
+- HTML injection in posts without account takeover / significant security impact
+- Version disclosure
+- HTTP-only exploits (no HTTPS downgrade)
+- DoS, spamming, social engineering, physical attacks

--- a/scopes/gojek.txt
+++ b/scopes/gojek.txt
@@ -1,0 +1,34 @@
+# Program: Gojek
+# Platform: YesWeHack (https://yeswehack.com/programs/gojek-bug-bounty-program)
+# Bounty: $50 (Low) - $5,000 (Critical)
+# Notes: Indonesian super app (ride-hailing, food delivery, logistics, payments).
+#        Large company (~35,000 employees) but strong Indonesian home advantage.
+#        Fresh YesWeHack program launched July 2025 — low researcher competition so far.
+#        Also has older HackerOne VDP (hackerone.com/gojek) — no bounty there, YesWeHack pays.
+# Automated tools: "Raw scanner outputs without analysis" are explicitly excluded as report type.
+#                  AI-validated findings (as SecBot produces) are fine. Use stealth profile.
+# Testing regions: Indonesia, Singapore, Vietnam, Thailand.
+# WARNING: Add X-HackerOne-Research header only if submitting to H1 VDP, not YesWeHack.
+
+In Scope
+www.gojek.com
+gofood.co.id
+gosend.id
+portal.gosend.id
+go-tix.id
+api.gojek.co.id
+*.gojekapi.com
+*.gopayapi.com
+*.findaya.com
+*.findaya.co.id
+*.mab.co.id
+
+Out of Scope
+- Social engineering and phishing attacks
+- Vulnerabilities requiring 0-day exploits (must be publicly known for 2+ months)
+- Raw/unanalyzed automated scanner output submitted as a report
+- Google Maps API key disclosures
+- Missing HTTP security headers without demonstrated exploit chain
+- Mobile: certificate pinning absence, root detection bypass, obfuscation issues
+- Infrastructure/TLS/DNS misconfigurations
+- Denial of service attacks

--- a/scopes/goto-financial.txt
+++ b/scopes/goto-financial.txt
@@ -1,0 +1,24 @@
+# Program: GoTo Financial
+# Platform: YesWeHack (https://yeswehack.com/programs/goto-financial-public-bounty-program)
+# Bounty: $50 (Low) - $7,000 (Critical)
+# Notes: Indonesian fintech arm of GoTo Group — GoPay digital wallet, GoPayLater BNPL,
+#        merchant payment infrastructure, and financial services for MSMEs.
+#        Higher bounty ceiling than Gojek program. Fresh YesWeHack program (July 2025).
+#        Indonesian home advantage — test from Indonesian IPs for realistic flows.
+#        Full scope asset list requires YesWeHack login to view — verify before testing.
+# Automated tools: YesWeHack standard rules apply. Use stealth profile + rate limiting.
+# Best attack surface: payment APIs, merchant dashboard auth, IDOR on transaction data,
+#                      JWT session handling, CORS on gopay.co.id subdomains.
+
+In Scope
+gopay.co.id
+*.gopay.co.id
+gotofinancial.com
+*.gotofinancial.com
+
+Out of Scope
+- Any domains NOT listed in the YesWeHack program scope (verify on platform before testing)
+- Social engineering and phishing attacks
+- Denial of service / resource exhaustion attacks
+- Data manipulation, leakage, or destruction of production data
+- Exploits requiring physical access to a device


### PR DESCRIPTION
## Summary

Bounty Scout cycle for 2026-04-13. Screened 10+ programs; added 4 new targets and disabled 1 existing one.

---

## New Programs Added

### 1. Discourse — HackerOne
- **Bounty:** $256 / $512 / $1,024 / $2,048+ (Low → Critical)
- **Tech:** Ruby on Rails (open source)
- **Scope:** `try.discourse.org` (dedicated public test instance)
- **Why:** Excellent payout history — paid $163K+ in a single year at avg ~$2,862/report. Small company (~100 employees), highly responsive (<1hr triage). No explicit automated scanner ban. SecBot's XSS, CSRF, IDOR, SQLi, auth-bypass checks map perfectly to a Ruby on Rails web app.
- **Warnings:** Reports must include step-by-step PoC. Raw scanner dumps will be rejected. 90-day disclosure embargo post-fix.

### 2. Gojek — YesWeHack
- **Bounty:** $50 – $5,000
- **Tech:** Mixed backend (Node.js, Go, Python micro-services)
- **Scope:** `www.gojek.com`, `gofood.co.id`, `gosend.id`, `portal.gosend.id`, `go-tix.id`, `api.gojek.co.id`, `*.gojekapi.com`, `*.gopayapi.com`, `*.findaya.com`, `*.mab.co.id`
- **Why:** Indonesian super app — strong home advantage for Indonesian-language flows, QRIS payment patterns, and local auth UX. YesWeHack program launched July 2025 → low researcher saturation so far. Rich API/web surface ideal for CORS, IDOR, JWT, and broken access control testing.
- **Warnings:** Large company (~35,000 employees). Raw scanner output explicitly excluded as report type — SecBot's AI-validated output is fine. Use stealth profile.

### 3. GoTo Financial — YesWeHack
- **Bounty:** $50 – $7,000 ← highest ceiling of any current registry target
- **Tech:** Mixed (fintech stack, REST APIs)
- **Scope:** `gopay.co.id`, `*.gopay.co.id`, `gotofinancial.com`, `*.gotofinancial.com`
- **Why:** Indonesian fintech arm of GoTo Group — GoPay digital wallet + GoPayLater BNPL. Fresh YesWeHack program (July 2025). Payment APIs and merchant dashboards are prime SecBot territory: auth bypass, IDOR on transaction data, CORS misconfig, SSRF in payment callbacks. Higher bounty ceiling than Gojek.
- **Warnings:** Full scope asset list requires YesWeHack login — verify before scanning. Part of a large group but fintech surfaces are well-suited to SecBot.

### 4. DANA Indonesia — YesWeHack
- **Bounty:** $0 – $3,000 + **$2,000 bonus** for face-verification login bypass
- **Tech:** Mixed (Java/Kotlin backend, REST APIs)
- **Scope:** `dana.id`, `www.dana.id`, `dashboard.dana.id`, `*.dana.id`
- **Why:** Indonesia's second-largest digital wallet (~1,000 employees). Mature, active program: 191 reports, <3 days first response, updated Feb 2025. Pure Indonesian company — excellent home advantage. Dashboard and payment flows are ideal for SecBot's auth, IDOR, CORS, and rate-limit checks.
- **Warnings:** Rate limiting is mandatory ("limit requests per second") — stealth profile only. Do NOT modify or touch real user data under any circumstances.

---

## Disabled Programs

### Cal.com — DISABLED
- **Reason:** Research confirmed this is a **VDP only** (no monetary rewards). The previous scope entry was wrong on three counts:
  1. Platform listed as HackerOne — actual reporting is via GitHub Security Advisories
  2. Bounty of "$100–$3,000 (estimated)" was unconfirmed and incorrect — cal.com/security confirms no bounty
  3. `*.companyhub.com` in scope was an error — CompanyHub is a completely separate CRM company
- Cal.com also **explicitly bans automated scanners** and excludes XSS, CSRF, and clickjacking — all major SecBot check categories.

---

## Programs Screened and Rejected This Cycle

| Program | Reason Rejected |
|---------|----------------|
| **Pintu** (Indonesian crypto) | Explicitly bans "automated testing using tools such as scanners" |
| **Tokopedia** | Stopped accepting new reports May 2024 — program closed |
| **KOMOJU** (Japanese payments) | Policy: "Do not use automated scanners or tools that generate large amounts of network traffic" |
| **Grab** (SEA super app) | ~35,000 employees; too large, high researcher competition |
| **Gitpod** | No monetary rewards — VDP only |
| **Basecamp / 37signals** | Invite-only private program — not accessible |
| **Zivver** (Dutch email security) | Acquired by Kiteworks June 2025 — program status uncertain post-acquisition; CSRF + clickjacking excluded |
| **Nextcloud** | Up to $10,000 but policy requires local reproduction before reporting — no live web target for SecBot |

---

## Existing Programs — Status Check

| Program | Status | Notes |
|---------|--------|-------|
| Kredivo | Active | Indonesian BNPL, RedStorm. Bounties low (~$190 critical) but home advantage retained. |
| AnyTask | Active | Bugcrowd, staging domain in scope. $250–$5,000. |
| Moneybird | Active | HackerOne, Ruby on Rails. Dutch accounting SaaS. No confirmed policy changes. |
| OpenProject | Active | YesWeHack, Rails + Angular. EUR 100–5,000. EU Commission-funded. |

https://claude.ai/code/session_01ECM39Fu8R37B3AdZF1tjoo