### PR TITLE
chore: update hunt registry — bounty scout [2026-04-13]

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -36,4 +36,32 @@
   scope_file: scopes/calcom.txt
   profile: stealth
   schedule: weekly
+  enabled: false
+
+- name: discourse
+  platform: hackerone
+  scope_file: scopes/discourse.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: gojek
+  platform: yeswehack
+  scope_file: scopes/gojek.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: gotofinancial
+  platform: yeswehack
+  scope_file: scopes/gotofinancial.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: danaindonesia
+  platform: yeswehack
+  scope_file: scopes/danaindonesia.txt
+  profile: stealth
+  schedule: weekly
   enabled: true

--- a/scopes/danaindonesia.txt
+++ b/scopes/danaindonesia.txt
@@ -1,0 +1,11 @@
+# Program: DANA Indonesia
+# Platform: YesWeHack
+# Bounty: $0 - $3,000 + $2,000 bonus
+# Notes: Indonesian digital wallet, OVO/DANA merger rumors, popular e-wallet
+In Scope
+dana.id
+*.dana.id
+dana.id.vip
+*.dana.id.vip
+
+Out of Scope

--- a/scopes/discourse.txt
+++ b/scopes/discourse.txt
@@ -1,0 +1,10 @@
+# Program: Discourse
+# Platform: HackerOne
+# Bounty: $256 - $2,048+
+# Notes: Ruby on Rails forum software, open-source, large community
+
+In Scope
+discourse.org
+*.discourse.org
+
+Out of Scope

--- a/scopes/gojek.txt
+++ b/scopes/gojek.txt
@@ -1,0 +1,12 @@
+# Program: Gojek
+# Platform: YesWeHack
+# Bounty: $50 - $5,000
+# Notes: Indonesian super app, multi-service platform (ride-hailing, payments, food delivery)
+
+In Scope
+gojek.com
+gojek.id
+*.gojek.com
+*.gojek.id
+
+Out of Scope

--- a/scopes/gotofinancial.txt
+++ b/scopes/gotofinancial.txt
@@ -1,0 +1,11 @@
+# Program: GoTo Financial
+# Platform: YesWeHack
+# Bounty: $50 - $7,000
+# Notes: GoPay fintech arm of GoTo, Indonesian digital payments
+In Scope
+gotofinance.com
+gotofinancial.com
+*.gotofinance.com
+*.gotofinancial.com
+
+Out of Scope


### PR DESCRIPTION
## Summary
Update hunt registry per Bounty Scout cycle 2026-04-13.

## Changes
- **Added 4 new programs:**
  - Discourse (HackerOne) - Ruby on Rails, $256-$2,048+
  - Gojek (YesWeHack) - Indonesian super app, $50-$5,000
  - GoTo Financial (YesWeHack) - GoPay fintech, $50-$7,000
  - DANA Indonesia (YesWeHack) - digital wallet, $0-$3,000 + $2,000 bonus

- **Disabled 1 program:**
  - Cal.com - Confirmed VDP only (no bounty), scanner ban, wrong scope info

## Testing
- YAML syntax validated via parseRegistry tests
- All scope files created in `scopes/` directory
- Registry tests pass (22/22)