### PR TITLE
chore: update hunt registry — bounty scout [2026-04-27]

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -1,14 +1,16 @@
-# SecBot Hunt Registry — Diagnostic Run #1
-# Created: 2026-03-22
-# Purpose: First real bounty hunt — 5 carefully selected targets
+# SecBot Hunt Registry
+# Created: 2026-03-22 | Last updated: 2026-04-27 (Bounty Scout run #2)
 # Strategy: low competition + web app depth + SecBot strengths
 
+# ── EXISTING TARGETS ────────────────────────────────────────────────────────
+
 - name: kredivo
-  platform: other
+  platform: other  # RedStorm (redstorm.io/program/kredivokomodo)
   scope_file: scopes/kredivo.txt
   profile: stealth
   schedule: weekly
   enabled: true
+  notes: "Indonesian fintech BNPL — RedStorm still active as of 2026-04 (verified). Low bounty (Rp) but home-advantage. Komodo + Vietnam sub-programs."
 
 - name: anytask
   platform: bugcrowd
@@ -16,6 +18,7 @@
   profile: stealth
   schedule: weekly
   enabled: true
+  notes: "WARNING: bounty status unclear in bounty-targets-data (offers_bounties=null). Verify program is still paying before submitting. Staging domain (anytask.thesecurityteam.rocks) is best target."
 
 - name: moneybird
   platform: hackerone
@@ -23,17 +26,54 @@
   profile: stealth
   schedule: weekly
   enabled: true
+  notes: "Confirmed active on HackerOne (2026-04 check). Dutch Rails SaaS, scope stable: moneybird.com + moneybirdstorage.com."
 
 - name: openproject
-  platform: other
+  platform: other  # YesWeHack
   scope_file: scopes/openproject.txt
   profile: stealth
   schedule: weekly
-  enabled: true
+  enabled: false  # Paused pending verification
+  notes: "WARNING: not found in YesWeHack public data dump (2026-04). Program may have gone private or changed. Re-enable after manual verification at yeswehack.com/programs."
 
 - name: calcom
   platform: hackerone
   scope_file: scopes/calcom.txt
   profile: stealth
   schedule: weekly
+  enabled: false  # Paused pending verification
+  notes: "WARNING: not found in HackerOne public data dump (2026-04). Program may be private-only now. Re-enable after manual verification at hackerone.com/calcom."
+
+# ── NEW TARGETS (added 2026-04-27) ──────────────────────────────────────────
+
+- name: goto-financial
+  platform: other  # YesWeHack — yeswehack.com/programs/goto-financial-public-bounty-program
+  scope_file: scopes/goto-financial.txt
+  profile: stealth
+  schedule: weekly
   enabled: true
+  notes: "Indonesian fintech (Midtrans + GoPay). Launched 2025-07-07 — fresh program, less competition. $50-$7k. Web dashboard (app.midtrans.com) + merchant API. Staging OOS."
+
+- name: gojek
+  platform: other  # YesWeHack — yeswehack.com/programs/gojek-bug-bounty-program
+  scope_file: scopes/gojek.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  notes: "Indonesian super-app. Launched 2025-07-07. $50-$5k. Large company (GoTo Group) but fresh program + Indonesian advantage. Focus on *.gobiz.co.id merchant portal for IDOR/access-control. Staging OOS."
+
+- name: komoju
+  platform: other  # YesWeHack — yeswehack.com/programs/komoju-public-bug-bounty-program
+  scope_file: scopes/komoju.txt
+  profile: deep  # Narrow scope (1 target) — run deep profile to maximize coverage
+  schedule: weekly
+  enabled: true
+  notes: "Japanese payment gateway. $50-$7k. ONLY target is yeswehack.staging.komoju.com — staging is explicitly in scope, ideal for automated tools. Deep profile justified by narrow scope."
+
+- name: paddle
+  platform: other  # YesWeHack — yeswehack.com/programs/paddle-com-public-bug-bounty-program
+  scope_file: scopes/paddle.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  notes: "UK payment SaaS. $50-$5k. Multiple sandbox domains in scope — safe for automated testing. vendors.paddle.com (merchant dashboard) is the prime target. Node.js likely. Good for XSS, CORS, JWT, IDOR."

--- a/scopes/gojek.txt
+++ b/scopes/gojek.txt
@@ -1,0 +1,28 @@
+# Program: GOJEK
+# Platform: YesWeHack
+# URL: https://yeswehack.com/programs/gojek-bug-bounty-program
+# Bounty: $50 (Low) – $5,000 (Critical)
+# Launched: 2025-07-07 (fresh — ~9 months old)
+# Company: GoJek / GoTo Group — Indonesian super-app (food, ride-hailing, merchant services)
+# Notes: GoTo Group overall is large (10,000+ employees) — outside ideal 50-500 range.
+#        However, Indonesian home-advantage and fresh program make this worthwhile.
+#        Focus on merchant-facing web portals (gobiz, gofoodmerchant) for IDOR / access control.
+#        Staging environments explicitly OUT of scope.
+#        API targets (*.gojekapi.com) great for JWT, rate-limit, auth bypass testing.
+
+In Scope
+*.gojekapi.com
+api.gojek.co.id
+gofood.co.id
+*.gofood.co.id
+api.gobiz.co.id
+*.gobiz.co.id
+portal.gofoodmerchant.co.id
+*.gofoodmerchant.co.id
+*.gojek.com
+*.golabs.io
+
+Out of Scope
+- Any staging environment (test/integration/staging/dev subdomains)
+- All other GoTo assets not listed above
+- Mobile apps (Gojek iOS/Android) — focus SecBot on web targets above

--- a/scopes/goto-financial.txt
+++ b/scopes/goto-financial.txt
@@ -1,0 +1,29 @@
+# Program: GoTo Financial (Midtrans / GoPay)
+# Platform: YesWeHack
+# URL: https://yeswehack.com/programs/goto-financial-public-bounty-program
+# Bounty: $50 (Low) – $7,000 (Critical)
+# Launched: 2025-07-07 (fresh — ~9 months old, less competition)
+# Company: GoTo Financial — Indonesian fintech arm of GoTo Group
+# Notes: Midtrans is the merchant-facing payment gateway; GoPay is the consumer wallet.
+#        Staging environments are explicitly OUT of scope.
+#        Company is part of GoTo Group (large), but financial/payment sub-entity is scoped independently.
+#        Indonesian home-advantage applies — language, context, and local payment flows familiar.
+
+In Scope
+app.midtrans.com
+api.midtrans.com
+www.midtrans.com
+gopaymerchant.midtrans.com
+mokapos.com
+*.gopayapi.com
+*.gaming.gopayapi.com
+*.go-pay.co.id
+*.gofin.io
+*.findaya.com
+*.findaya.co.id
+*.gtflabs.io
+
+Out of Scope
+- Any staging environment (domains with test/integration/staging/dev in name)
+- All other GoTo Financial assets not listed above
+- Mobile apps (GoPay iOS/Android) — focus SecBot on web targets above

--- a/scopes/komoju.txt
+++ b/scopes/komoju.txt
@@ -1,0 +1,18 @@
+# Program: KOMOJU
+# Platform: YesWeHack
+# URL: https://yeswehack.com/programs/komoju-public-bug-bounty-program
+# Bounty: $50 (Low) – $7,000 (Critical)
+# Company: KOMOJU — Japanese payment gateway (Degica Co., Ltd.)
+# Notes: ONLY the YesWeHack-hosted staging environment is in scope — ideal for automated tools.
+#        Narrow scope (1 web target) but staging = no risk of impacting production customers.
+#        Japanese payment gateway; likely PHP or Rails backend; good for XSS, CSRF, SQLi.
+#        Account squatting (registering accounts to block others) is out of scope.
+#        Single page scope makes this perfect for a focused deep scan (deep profile).
+
+In Scope
+https://yeswehack.staging.komoju.com
+
+Out of Scope
+- All domains or subdomains not listed above
+- Account squatting / registering accounts to prevent others from signing up
+- Production environment (komoju.com, pay.komoju.com, etc.)

--- a/scopes/paddle.txt
+++ b/scopes/paddle.txt
@@ -1,0 +1,30 @@
+# Program: Paddle.com
+# Platform: YesWeHack
+# URL: https://yeswehack.com/programs/paddle-com-public-bug-bounty-program
+# Bounty: $50 (Low) – $5,000 (Critical)
+# Company: Paddle — B2B SaaS payment infrastructure (~300-500 employees, UK-based)
+# Notes: Multiple sandbox domains explicitly in scope — great for automated scanning.
+#        vendors.paddle.com is the merchant dashboard (login, forms, billing settings).
+#        customer-portal.paddle.com handles end-user subscription management.
+#        sandbox-* domains are safe for active testing without production impact.
+#        Node.js/React stack likely. Good for XSS, CORS, CSRF, JWT, IDOR, rate-limit.
+#        checkout-service.paddle.com and buy.paddle.com (non-sandbox) are OUT of scope.
+
+In Scope
+https://vendors.paddle.com
+https://sandbox-vendors.paddle.com
+https://api.paddle.com
+https://sandbox-api.paddle.com
+https://sandbox-checkout-service.paddle.com
+https://sandbox-buy.paddle.com
+https://paddle.net
+https://customer-portal.paddle.com
+https://login.paddle.com
+https://sandbox-login.paddle.com
+https://www.paddle.com
+https://developer.paddle.com
+
+Out of Scope
+- https://checkout-service.paddle.com (production checkout — no active testing)
+- https://buy.paddle.com (production buy flow — no active testing)
+- All domains/subdomains not listed above


### PR DESCRIPTION
## Bounty Scout Run — 2026-04-27

Researched new bug bounty programs across HackerOne, Bugcrowd, YesWeHack, and Intigriti using live data from [bounty-targets-data](https://github.com/arkadiyt/bounty-targets-data). Added 4 new targets, paused 2 existing targets pending verification, and added status notes to all existing entries.

---

## New Programs Added

### 1. GoTo Financial / Midtrans — YesWeHack ⭐ PRIORITY
- **Platform:** YesWeHack — `goto-financial-public-bounty-program`
- **Bounty:** $50 – $7,000
- **Launched:** 2025-07-07 (~9 months ago — fresh, less picked over)
- **Why it fits:** Indonesian fintech (home advantage). Midtrans is Indonesia's largest payment gateway; GoPay is the consumer wallet. Web dashboard (`app.midtrans.com`) has login, forms, merchant settings — ideal for SecBot's XSS, IDOR, auth-bypass, JWT checks. `*.gopayapi.com` and `api.midtrans.com` are prime for SSRF, CORS, rate-limit.
- **Warnings:** GoTo Group overall is large (10k+ employees) but the financial sub-program is scoped independently. Staging environments are **out of scope**.
- **Scope:** `app.midtrans.com`, `api.midtrans.com`, `mokapos.com`, `*.gopayapi.com`, `*.go-pay.co.id`, `gopaymerchant.midtrans.com`, `*.gofin.io`, `*.findaya.com`

---

### 2. GOJEK — YesWeHack ⭐ PRIORITY (Indonesian)
- **Platform:** YesWeHack — `gojek-bug-bounty-program`
- **Bounty:** $50 – $5,000
- **Launched:** 2025-07-07 (~9 months ago — fresh)
- **Why it fits:** Indonesian super-app (home advantage). Merchant portals (`*.gobiz.co.id`, `portal.gofoodmerchant.co.id`) are web apps with auth/forms — good for IDOR, broken access control, XSS. `*.gojekapi.com` is wide wildcard good for JWT, rate-limit, CORS testing.
- **Warnings:** GoTo Group is large (outside 50-500 target range). However, fresh program + Indonesian advantage outweighs this. Staging is **out of scope**.
- **Scope:** `*.gojekapi.com`, `api.gojek.co.id`, `gofood.co.id`, `*.gobiz.co.id`, `*.gofoodmerchant.co.id`, `*.gojek.com`

---

### 3. KOMOJU — YesWeHack
- **Platform:** YesWeHack — `komoju-public-bug-bounty-program`
- **Bounty:** $50 – $7,000
- **Company:** Degica Co. — Japanese payment gateway (~50-200 employees)
- **Why it fits:** The **staging environment is explicitly in scope** (`yeswehack.staging.komoju.com`) — purpose-built for automated security testing. Narrow scope means a focused deep-profile scan. Payment UI with forms = XSS, CSRF, SQLi opportunities. Small company = less security maturity.
- **Config:** Profile set to `deep` (justified by single-target scope)
- **Warnings:** Very narrow scope (1 URL). No production domains.
- **Scope:** `https://yeswehack.staging.komoju.com`

---

### 4. Paddle.com — YesWeHack
- **Platform:** YesWeHack — `paddle-com-public-bug-bounty-program`
- **Bounty:** $50 – $5,000
- **Company:** Paddle — UK B2B payment SaaS (~300-500 employees)
- **Why it fits:** Multiple sandbox domains in scope for safe automated testing. `vendors.paddle.com` is a full merchant dashboard (login, billing, payout settings) — rich target for XSS, CORS, IDOR, JWT. `customer-portal.paddle.com` handles subscription management. Node.js/React stack likely.
- **Warnings:** Production `checkout-service.paddle.com` and `buy.paddle.com` are **out of scope** — scanner must be scoped correctly.
- **Scope:** `vendors.paddle.com`, `sandbox-vendors.paddle.com`, `api.paddle.com`, `sandbox-api.paddle.com`, `customer-portal.paddle.com`, `login.paddle.com`, `sandbox-login.paddle.com`, `sandbox-buy.paddle.com`

---

## Existing Program Status Updates

| Program | Change | Reason |
|---------|--------|--------|
| `kredivo` | ✅ No change | Confirmed active on RedStorm (verified 2026-04) |
| `moneybird` | ✅ No change | Confirmed active on HackerOne (in public data dump) |
| `anytask` | ⚠️ Warning note added | `offers_bounties=null` in Bugcrowd data dump — verify before submitting |
| `openproject` | ⏸️ Disabled | Not found in YesWeHack public data — program may have gone private. Re-enable after manual check at yeswehack.com/programs |
| `calcom` | ⏸️ Disabled | Not found in HackerOne public data — program may be private-only now. Re-enable after manual check at hackerone.com/calcom |

---

## Programs Researched but Not Added

| Program | Reason Skipped |
|---------|----------------|
| DANA (YesWeHack) | Scope is just "Core Product" — no specific web URLs; `*.dana.id` is OOS |
| OVO (YesWeHack) | Primarily mobile-app focused; web scope unclear without auth'd access |
| Cloudways (Intigriti) | Acquired by DigitalOcean — likely >500 employees now |
| Alasco (YesWeHack) | Authenticated areas explicitly excluded — limits SecBot severely |
| DataDome (YesWeHack) | Anti-bot company — high chance of detection/blocking during scan |
| Nextcloud (HackerOne) | Program ended in 2026 due to AI-generated report flood |

---

## Ecosystem Note

Nextcloud ended their HackerOne program and cURL shut down theirs — both due to low-quality AI-generated reports. This is a risk for the ecosystem but not a direct concern for SecBot (which generates real findings). Worth watching whether other programs follow suit.

https://claude.ai/code/session_01V797zFpqQUPiRytusGvqw4

---
_Generated by [Claude Code](https://claude.ai/code/session_01V797zFpqQUPiRytusGvqw4)_