### PR TITLE
chore: update hunt registry — bounty scout 2026-05-04

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -1,7 +1,16 @@
-# SecBot Hunt Registry — Diagnostic Run #1
-# Created: 2026-03-22
-# Purpose: First real bounty hunt — 5 carefully selected targets
-# Strategy: low competition + web app depth + SecBot strengths
+# SecBot Hunt Registry
+# Created: 2026-03-22  Last updated: 2026-05-04 (Bounty Scout run)
+# Purpose: Bounty hunting targets — web app depth + SecBot strengths
+# Strategy: low competition + SEA home-advantage + fresh/recent programs
+#
+# Change log (2026-05-04):
+#   + Added goto-financial (YesWeHack) — Indonesian fintech, GoPay+Midtrans, $50-$7k
+#   + Added gojek (YesWeHack)          — Indonesian super-app, $50-$5k
+#   + Added maya (YesWeHack)            — Philippine digital bank, $50-$5k
+#   ~ Disabled calcom: security page explicitly bans automated scanners;
+#     re-enable only after sandbox authorization from security@cal.com
+
+# ── Existing targets ────────────────────────────────────────────────────────
 
 - name: kredivo
   platform: other
@@ -25,7 +34,7 @@
   enabled: true
 
 - name: openproject
-  platform: other
+  platform: yeswehack
   scope_file: scopes/openproject.txt
   profile: stealth
   schedule: weekly
@@ -34,6 +43,29 @@
 - name: calcom
   platform: hackerone
   scope_file: scopes/calcom.txt
+  profile: stealth
+  schedule: weekly
+  enabled: false  # Cal.com bans automated scanners — needs sandbox auth first
+
+# ── New targets (2026-05-04) ─────────────────────────────────────────────────
+
+- name: goto-financial
+  platform: yeswehack
+  scope_file: scopes/goto-financial.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: gojek
+  platform: yeswehack
+  scope_file: scopes/gojek.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: maya
+  platform: yeswehack
+  scope_file: scopes/maya.txt
   profile: stealth
   schedule: weekly
   enabled: true

--- a/scopes/calcom.txt
+++ b/scopes/calcom.txt
@@ -1,7 +1,13 @@
 # Program: Cal.com
-# Platform: HackerOne
+# Platform: HackerOne (cal_)
 # Bounty: $100 - $3,000 (estimated)
 # Notes: Open-source scheduling (Next.js/TypeScript), code on GitHub, small startup
+# !! WARNING: Cal.com security page (cal.com/security) explicitly states
+# !! "do not run automated scanners on our infrastructure or dashboard."
+# !! To run automated tests, contact security@cal.com to get a sandbox environment.
+# !! SecBot should NOT scan this target until sandbox authorization is confirmed.
+# !! Target is DISABLED in hunt-registry.yaml until sandbox is arranged.
+# Note: *.companyhub.com in scope is unverified — may need confirmation with program.
 
 In Scope
 app.cal.com
@@ -9,3 +15,4 @@ app.cal.com
 
 Out of Scope
 - cal.com (marketing site only, not the app)
+- Automated scanning without explicit sandbox authorization from security@cal.com

--- a/scopes/gojek.txt
+++ b/scopes/gojek.txt
@@ -1,0 +1,21 @@
+# Program: Gojek
+# Platform: YesWeHack (gojek-bug-bounty-program)
+# Bounty: $50 - $5,000
+# Notes: Indonesian super-app — ride-hailing, food delivery (GoFood), logistics
+#   (GoSend), merchant tools (GoBiz). Also on HackerOne ($100–$5k) but H1 policy
+#   requires a unique X-identifier header in every request — not yet supported by
+#   SecBot. Use this YesWeHack program instead (same scope, no header requirement).
+#   Wildcard scope across major service domains = very wide attack surface.
+
+In Scope
+*.gojekapi.com
+*.gofood.co.id
+*.gobiz.co.id
+*.gojek.com
+*.golabs.io
+*.gofoodmerchant.co.id
+
+Out of Scope
+- Staging environments (subdomains containing test/integration/staging)
+- Mobile apps (iOS/Android — SecBot is web-only)
+- GoPay / Midtrans assets (covered by the separate GoTo Financial program)

--- a/scopes/goto-financial.txt
+++ b/scopes/goto-financial.txt
@@ -1,0 +1,27 @@
+# Program: GoTo Financial
+# Platform: YesWeHack (goto-financial-public-bounty-program)
+# Bounty: $50 - $7,000
+# Notes: Indonesian fintech arm of GoTo Group. Operates GoPay (largest digital
+#   wallet in Indonesia) and Midtrans (largest payment gateway in Indonesia).
+#   Also includes Moka (POS SaaS), Findaya (lending), and GTF Labs.
+#   Program added to YesWeHack July 2025. No automated tool restrictions found.
+#   Large company (GoTo Group ~4k employees) but SEA home-advantage + fresh scope.
+
+In Scope
+*.gopayapi.com
+gopaymerchant.midtrans.com
+mokapos.com
+*.go-pay.co.id
+api.midtrans.com
+app.midtrans.com
+www.midtrans.com
+*.gaming.gopayapi.com
+*.gofin.io
+*.findaya.com
+*.findaya.co.id
+*.gtflabs.io
+
+Out of Scope
+- Staging environments (subdomains containing test/integration/staging)
+- Mobile apps (iOS/Android GoPay app — SecBot is web-only)
+- Any GoTo/Gojek asset not explicitly listed above

--- a/scopes/maya.txt
+++ b/scopes/maya.txt
@@ -1,0 +1,23 @@
+# Program: Maya
+# Platform: YesWeHack (maya-public-bug-bounty-program)
+# Bounty: $50 - $5,000
+# Notes: Philippine digital bank and e-wallet (formerly PayMaya / Voyager
+#   Innovations). ~500 employees. SEA priority — low competition, home advantage.
+#   Scope is API-heavy (payment APIs) — good target for CORS, SSRF, IDOR, JWT,
+#   broken access control, and rate-limit checks. Allow up to 5 collaborator
+#   reward splits on YesWeHack. Sandbox accounts: register via tinbo.ph for a
+#   free +63 virtual number (valid 30–90 days).
+
+In Scope
+api.paymaya.com
+pg.paymaya.com
+payoutapi.maya.ph
+op.paymaya.com
+connect.paymaya.com
+paymayabiller-prod.paymaya.com
+
+Out of Scope
+- Non-production environments (test/dev/staging/sandbox subdomains)
+- Other paymaya.com or maya.ph subdomains not explicitly listed above
+- Mobile apps (iOS/Android — SecBot is web-only)
+- Exposed secrets/credentials that don't directly affect an in-scope target


### PR DESCRIPTION
## Summary

Bounty Scout agent run for 2026-05-04. Researched 15+ programs across HackerOne, Bugcrowd, Intigriti, YesWeHack, and Cyber Army Indonesia. Added 3 new SEA-priority targets and disabled 1 incompatible existing target.

---

## New Targets

### 1. GoTo Financial — YesWeHack `goto-financial-public-bounty-program`
- **Bounty:** $50 – $7,000
- **Why it's a good fit:** Highest-priority new target. GoTo Financial is the fintech arm of GoTo Group (Gojek + Tokopedia merger), running **GoPay** (largest Indonesian digital wallet) and **Midtrans** (largest Indonesian payment gateway). Also includes Moka POS, Findaya (lending), and GTF Labs. Program was added to YesWeHack in **July 2025** — relatively fresh, less picked over.
- **SecBot strengths:** CORS on payment APIs, CSRF on payment flows, SSRF, IDOR across merchant/consumer APIs, JWT security on Midtrans tokens, broken access control, rate limiting on payment endpoints.
- **Scope:** `*.gopayapi.com`, `*.go-pay.co.id`, `api/app/www.midtrans.com`, `gopaymerchant.midtrans.com`, `mokapos.com`, `*.gofin.io`, `*.findaya.com`, `*.findaya.co.id`, `*.gtflabs.io`, `*.gaming.gopayapi.com`
- **Warnings:** Large parent company (GoTo Group ~4k employees). No automated tool restrictions found in program policy.

### 2. Gojek — YesWeHack `gojek-bug-bounty-program`
- **Bounty:** $50 – $5,000
- **Why it's a good fit:** Indonesian super-app with massive wildcard scope across ride-hailing, GoFood, GoSend, and GoBiz merchant services. Wide attack surface = more opportunities for IDOR, CORS, XSS, and broken access control findings.
- **SecBot strengths:** All active checks applicable. Wildcard domains likely surface many subdomains via SecBot's CT enumeration.
- **Scope:** `*.gojekapi.com`, `*.gojek.com`, `*.gofood.co.id`, `*.gobiz.co.id`, `*.golabs.io`, `*.gofoodmerchant.co.id`
- **Warnings:** Program also exists on HackerOne ($100–$5k) but H1 policy requires a unique identification header in every request — not currently supported by SecBot. Using YesWeHack program instead (equivalent scope, no header requirement). Staging subdomains are explicitly out of scope.

### 3. Maya — YesWeHack `maya-public-bug-bounty-program`
- **Bounty:** $50 – $5,000
- **Why it's a good fit:** Philippine digital bank and e-wallet (formerly PayMaya / Voyager Innovations), ~500 employees, SEA home-advantage, low Western researcher competition. API-focused scope is well-suited to SecBot's CORS, SSRF, IDOR, JWT, and rate-limit checks.
- **SecBot strengths:** Payment API attack surface — CORS misconfigurations, SSRF via payment callbacks, IDOR on transaction IDs, JWT/session security, rate limiting on auth endpoints.
- **Scope:** `api.paymaya.com`, `pg.paymaya.com`, `payoutapi.maya.ph`, `op.paymaya.com`, `connect.paymaya.com`, `paymayabiller-prod.paymaya.com`
- **Warnings:** Scope is production APIs only (no staging). Sandbox accounts available via tinbo.ph (+63 virtual numbers, 30–90 day validity).

---

## Existing Target Changes

### Cal.com — DISABLED (`enabled: false`)
- **Reason:** Cal.com's security page (`cal.com/security`) explicitly states **"do not run automated scanners on our infrastructure or dashboard."** Contact `security@cal.com` to arrange a sandbox environment before running SecBot.
- **Also noted:** The `*.companyhub.com` entry in the scope file is unverified — CompanyHub is an unrelated CRM company. Needs confirmation with the program before scanning.
- **Action needed:** Email security@cal.com requesting a sandbox. Re-enable once confirmed.

---

## Researched & Rejected

| Program | Platform | Reason Rejected |
|---------|----------|-----------------|
| Jenkins | YesWeHack | Policy explicitly: "submissions from automated tools won't be considered" |
| PDQ | Intigriti | Policy: "Scanning is strictly prohibited" |
| Nextcloud | YesWeHack/H1 | Ended paid bug bounty program April 2026 |
| KOMOJU | YesWeHack | $50–$7k but scope limited to a single staging URL |
| Tokopedia | Self-hosted | Stopped accepting new reports May 2024 |
| BigBlueButton | YesWeHack | Scope unclear; needs manual review before adding |
| Keycloak | YesWeHack | IAM server focus — less web-app attack surface for SecBot |

---

## Test Plan
- [ ] Verify `secbot hunt --registry hunt-registry.yaml` parses the new entries without errors
- [ ] Confirm `goto-financial` first scan targets `app.midtrans.com` (best web UI entry point in scope)
- [ ] Confirm `gojek` first scan targets `www.gojek.com` (main web app)
- [ ] Confirm `maya` first scan targets `api.paymaya.com` (primary API scope)
- [ ] Verify `calcom` is skipped in the hunt run (enabled: false)
- [ ] Email security@cal.com requesting sandbox authorization

https://claude.ai/code/session_01W8aZrPqZUiY5rmudVWTH59

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8aZrPqZUiY5rmudVWTH59)_