### PR TITLE
chore: update hunt registry — bounty scout 2026-05-18

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -1,7 +1,7 @@
-# SecBot Hunt Registry — Diagnostic Run #1
-# Created: 2026-03-22
-# Purpose: First real bounty hunt — 5 carefully selected targets
-# Strategy: low competition + web app depth + SecBot strengths
+# SecBot Hunt Registry
+# Created: 2026-03-22  |  Last updated: 2026-05-18 (Bounty Scout run #2)
+# Purpose: Ongoing bounty hunt — curated targets matched to SecBot strengths
+# Strategy: low competition + web app depth + Indonesian/SEA priority
 
 - name: kredivo
   platform: other
@@ -37,3 +37,38 @@
   profile: stealth
   schedule: weekly
   enabled: true
+
+# --- Added 2026-05-18 by Bounty Scout ---
+
+- name: gojek
+  platform: hackerone
+  scope_file: scopes/gojek.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  notes: >
+    Indonesian super-app (GoTo Group). $100–$5,000. Home-advantage play.
+    MUST include X-Bug-Bounty-Testing header in every request.
+    Focus on CORS, GraphQL, JWT, IDOR — XSS/SQLi are saturated here.
+
+- name: neon
+  platform: hackerone
+  scope_file: scopes/neon.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  notes: >
+    Serverless PostgreSQL startup. $150–$3,000. Went public Feb 2025 —
+    low-competition window. Node.js/Next.js console. Staging in scope.
+    Best SecBot checks: API auth, CORS, SSRF, JWT, IDOR.
+
+- name: mattermost
+  platform: bugcrowd
+  scope_file: scopes/mattermost.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  notes: >
+    Open-source messaging (Go+React). Public on Bugcrowd since Nov 2024.
+    Read github.com/mattermost/mattermost before scanning for high signal.
+    Fresh plugin targets (Boards, Copilot, MS Calendar) are lowest competition.

--- a/scopes/gojek.txt
+++ b/scopes/gojek.txt
@@ -1,0 +1,33 @@
+# Program: Gojek
+# Platform: HackerOne (hackerone.com/gojek)
+# Bounty: $100 (minor/P5) — $5,000 (critical/P1)
+# Company: GoTo Group, Indonesian super-app (ride-hailing, food, payments)
+# Notes: Oldest Indonesian BB program on H1; home-advantage play; requires custom
+#        X-Bug-Bounty-Testing: <your-h1-username> header on every request so
+#        Gojek can separate test traffic. Raw scanner output not accepted —
+#        manual PoC required. Program active since ~2019; publicly expanded 2022.
+# Warnings: Competitive (850+ researchers over program lifetime). Focus on
+#            less-common checks (GraphQL, JWT, CORS, IDOR) to avoid saturated
+#            XSS/SQLi reports. Scope added OVO Indonesia in 2023-2024.
+
+In Scope
+gojek.com
+*.gofood.co.id
+*.gojek.com/food
+driver.gojek.com
+pay.gojek.com
+merchant.gojek.com
+id.gojek.com
+
+Out of Scope
+- Mobile APK reverse engineering (separate mobile program)
+- Third-party services not controlled by Gojek
+- *.gojek.com subdomains not explicitly listed (check H1 policy for current list)
+- Denial of service / rate limit exhaustion
+- Social engineering / phishing
+- Issues requiring physical access
+
+Notes
+- Always include X-Bug-Bounty-Testing header with H1 username in all requests
+- Gojek may award up to $2,000 bonus for exceptional quality reports
+- Check hackerone.com/gojek for the authoritative, up-to-date scope list

--- a/scopes/mattermost.txt
+++ b/scopes/mattermost.txt
@@ -1,0 +1,33 @@
+# Program: Mattermost
+# Platform: Bugcrowd (bugcrowd.com/engagements/mattermost-mbb-public)
+# Bounty: Bugcrowd standard table (specific amounts not publicly disclosed;
+#          typical range $150—$5,000 based on severity)
+# Company: Mattermost Inc. — open-source team messaging; ~300 employees
+# Notes: Transitioned from HackerOne → Bugcrowd November 2024 with expanded scope
+#        (+4 new plugin targets). Stack: Go backend, React frontend, Postgres DB.
+#        Open-source repo (github.com/mattermost/mattermost) — read code before
+#        testing for much higher signal. Focus: auth bypass, IDOR, CORS, JWT,
+#        websocket security, plugin sandbox escapes.
+# Warnings: Automated scanner raw dumps not accepted on Bugcrowd. Require PoC.
+#            Program is public so some competition, but plugin scope is fresh.
+
+In Scope
+mattermost.com
+*.mattermost.com
+mattermost.cloud
+Mattermost Boards plugin
+Mattermost Copilot plugin
+Mattermost Microsoft Calendar Plugin
+Mattermost Plugin for Microsoft Teams Meetings
+
+Out of Scope
+- Self-hosted Mattermost deployments (test against mattermost.com only)
+- Third-party integrations not controlled by Mattermost
+- Denial of service
+- Social engineering
+
+Notes
+- Program moved to Bugcrowd Nov 6, 2024 — previously on HackerOne (closed)
+- Code is open source: github.com/mattermost/mattermost — audit before scanning
+- Plugin targets added Nov 2024 are lowest-competition scope
+- Check bugcrowd.com/engagements/mattermost-mbb-public for authoritative scope

--- a/scopes/neon.txt
+++ b/scopes/neon.txt
@@ -1,0 +1,29 @@
+# Program: Neon
+# Platform: HackerOne (hackerone.com/neon_bbp)
+# Bounty: $150 (low) — $3,000 (critical); expanding throughout 2025
+# Company: Neon Inc. — serverless PostgreSQL (formerly Neondatabase); ~80 employees
+# Notes: Program went PUBLIC Feb 2025 after ~3 months private. Low competition
+#        window — newly public means low-hanging fruit still available.
+#        Stack: Node.js / Rust / Go backend, Next.js console. Auth via GitHub/Google
+#        OAuth + email magic links. Staging env in scope (use Stripe test cards).
+#        Response SLA: ack 2 days, triage 10 days, payment 30 days.
+# Warnings: Scope is deliberately narrow — web app + API only (no infra/cloud).
+#            Do not test customer database content; focus on the control plane.
+
+In Scope
+console.neon.tech
+api.neon.tech
+neon.tech (auth/API paths, not marketing)
+
+Out of Scope
+- Customer Postgres databases (tenant data)
+- Physical infrastructure / cloud provider layer
+- Third-party OAuth providers (GitHub, Google)
+- Stripe payment processing backend
+
+Notes
+- Both staging (neon-staging.tech) and production are in scope — prefer staging
+  for destructive or high-noise tests
+- Researchers can sign up as regular users; Stripe test cards available on staging
+- Report to: security@neon.tech or via HackerOne
+- Rewards expected to increase as program matures


### PR DESCRIPTION
## Bounty Scout Run #2 — 2026-05-18

Researched public bug bounty programs across HackerOne, Bugcrowd, and bounty-tracker sources (bbradar.io, firebounty.com, hackstack.app). Added 3 new programs, verified 5 existing programs still active.

---

## New Targets Added

### 1. Gojek — HackerOne (`hackerone.com/gojek`)
| | |
|---|---|
| **Platform** | HackerOne (public) |
| **Bounty** | $100 (minor) — $5,000 (critical/P1) |
| **Company size** | GoTo Group (~2,000 employees in security-relevant web teams) |
| **Tech stack** | Go, Node.js, React, Python microservices |
| **Why it's a fit** | Indonesian company = home advantage + lower local competition. Program covers gojek.com web apps, GoFood, GoSend, and merchant portals. SecBot's CORS, GraphQL, JWT, and IDOR checks are strong here. App has deep API surface (food ordering, payments, driver dispatch) with complex auth flows. |
| **Warnings** | Program has run since 2019 so XSS/SQLi are well-picked-over. Focus on less common checks. **Must include `X-Bug-Bounty-Testing: <h1-username>` header in every request** — without it, Gojek cannot separate test traffic and will reject reports. Raw scanner dumps not accepted; manual PoC required. |

---

### 2. Neon — HackerOne (`hackerone.com/neon_bbp`)
| | |
|---|---|
| **Platform** | HackerOne (went **public Feb 2025**) |
| **Bounty** | $150 (low) — $3,000 (critical); expanding throughout 2025 |
| **Company size** | ~80 employees (Neon Inc., YC-backed) |
| **Tech stack** | Node.js / Rust / Go backend, Next.js console, Postgres |
| **Why it's a fit** | Newly public program = low-competition window. Small startup with complex auth (GitHub/Google OAuth + magic links) and deep API surface (database provisioning, connection pooling, branching API). Staging environment in scope (Stripe test cards provided). SecBot's API auth, CORS, SSRF, JWT, and IDOR checks map directly to their attack surface. |
| **Warnings** | Scope is narrow — web app + API only, no infra or customer database content. Do not touch tenant Postgres data. Prefer staging for noisy/destructive tests. |

---

### 3. Mattermost — Bugcrowd (`bugcrowd.com/engagements/mattermost-mbb-public`)
| | |
|---|---|
| **Platform** | Bugcrowd (transitioned from HackerOne **November 2024**) |
| **Bounty** | Bugcrowd standard severity table (estimated $150–$5,000) |
| **Company size** | ~300 employees |
| **Tech stack** | Go backend, React frontend, PostgreSQL, WebSocket-heavy |
| **Why it's a fit** | Open-source repo (`github.com/mattermost/mattermost`) means we can audit code before scanning — dramatically higher signal-to-noise. Scope was expanded with 4 new plugin targets in Nov 2024 (Boards, Copilot, MS Calendar, MS Teams Meetings) that are freshest and least-picked. WebSocket auth, plugin sandboxing, and CORS are strong SecBot angles. |
| **Warnings** | Bugcrowd rejects raw scanner output — always include manual PoC. Self-hosted Mattermost is out of scope; test against mattermost.com only. |

---

## Existing Programs — Status Check

| Program | Platform | Status | Changes Found |
|---------|----------|--------|---------------|
| kredivo | RedStorm | ✅ Active | None — Komodo product is now a separate listing (`kredivokomodo`) but original scope unchanged |
| anytask | Bugcrowd | ✅ Active | None found |
| moneybird | HackerOne | ✅ Active | None found |
| openproject | YesWeHack | ✅ Active | None found |
| calcom | HackerOne | ✅ Active | None found — notable: a critical auth bypass was publicly disclosed recently, confirming program is active and paying |

---

## Programs Evaluated but Not Added

| Program | Reason Skipped |
|---------|---------------|
| **Traveloka** (Bugcrowd) | ~3,300 employees — too large per criteria, highly competitive |
| **Grab** (HackerOne) | 850+ researchers over 10 years, very competitive; OVO scope is interesting but noise-to-signal too high |
| **Remitly** (HackerOne) | ~2,000 employees, US-listed fintech, private program since 2018 — already heavily tested |
| **Hostinger** (HackerOne) | $50 minimum bounty too low to justify scan time |
| **Supabase** (HackerOne) | VDP only as of research date (paid bounties "launching in 2026") |
| **ProConnect/DINUM** (YesWeHack) | French government SSO — language barrier, out-of-jurisdiction |

---

## Files Changed
- `hunt-registry.yaml` — added 3 new entries, updated header comment
- `scopes/gojek.txt` — new scope file
- `scopes/neon.txt` — new scope file
- `scopes/mattermost.txt` — new scope file

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhDQBVPy1Gqdo9xWPfs4SX)_