### PR TITLE
chore: update hunt registry — bounty scout [2026-05-25]

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -1,7 +1,7 @@
-# SecBot Hunt Registry — Diagnostic Run #1
-# Created: 2026-03-22
-# Purpose: First real bounty hunt — 5 carefully selected targets
-# Strategy: low competition + web app depth + SecBot strengths
+# SecBot Hunt Registry
+# Created: 2026-03-22 | Last updated: 2026-05-25 (Bounty Scout)
+# Purpose: Curated bounty targets matched to SecBot's check suite
+# Strategy: low competition + web app depth + SecBot strengths + SEA home advantage
 
 - name: kredivo
   platform: other
@@ -34,6 +34,36 @@
 - name: calcom
   platform: hackerone
   scope_file: scopes/calcom.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+# --- New targets added 2026-05-25 (Bounty Scout) ---
+
+- name: goto-financial
+  platform: yeswehack
+  scope_file: scopes/goto-financial.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: gojek
+  platform: yeswehack
+  scope_file: scopes/gojek.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: paddle
+  platform: yeswehack
+  scope_file: scopes/paddle.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: neon
+  platform: hackerone
+  scope_file: scopes/neon.txt
   profile: stealth
   schedule: weekly
   enabled: true

--- a/scopes/calcom.txt
+++ b/scopes/calcom.txt
@@ -1,7 +1,10 @@
 # Program: Cal.com
-# Platform: HackerOne
+# Platform: HackerOne (hackerone.com/cal_)
 # Bounty: $100 - $3,000 (estimated)
-# Notes: Open-source scheduling (Next.js/TypeScript), code on GitHub, small startup
+# Notes: Scheduling SaaS (Next.js/TypeScript). Previously open-source; announced going
+#   closed-source in 2025 (cited AI-assisted exploit discovery as security risk).
+#   Program status: still active on HackerOne as of 2026-05.
+#   WARNING: *.companyhub.com scope entry needs manual verification — unclear if still valid.
 
 In Scope
 app.cal.com

--- a/scopes/gojek.txt
+++ b/scopes/gojek.txt
@@ -1,0 +1,26 @@
+# Program: Gojek
+# Platform: YesWeHack (yeswehack.com/programs/gojek-bug-bounty-program)
+# Note: Gojek also maintains a legacy HackerOne program — use YesWeHack for reporting.
+# Bounty: $5 (low) – $5,000 (critical)
+# Notes: Indonesian super-app — ride-hailing, food delivery, merchant platform.
+#   Largest web attack surface among Indonesian programs: merchant portals, APIs, dashboards.
+#   Home advantage: Indonesian-language flows, local auth patterns, OTP/PIN login.
+#   No explicit automated-scanning ban found; stealth profile mandatory.
+#   SecBot strengths: merchant portal (IDOR/BFLA), food-ordering API (CORS/SSRF), auth.
+
+In Scope
+*.gojek.com
+api.gojek.co.id
+gofood.co.id
+*.gofood.co.id
+*.gofoodmerchant.co.id
+portal.gofoodmerchant.co.id
+api.gobiz.co.id
+*.gobiz.co.id
+*.gojekapi.com
+*.golabs.io
+
+Out of Scope
+- Staging/test environments
+- Mobile apps (iOS/Android) — SecBot is web-only
+- Any Gojek assets not listed above (driver app infrastructure, etc.)

--- a/scopes/goto-financial.txt
+++ b/scopes/goto-financial.txt
@@ -1,0 +1,27 @@
+# Program: GoTo Financial
+# Platform: YesWeHack (yeswehack.com/programs/goto-financial-public-bounty-program)
+# Bounty: $5 (low) – $7,000 (critical)
+# Notes: Indonesian fintech — GoPay digital wallet, Midtrans payment gateway, Moka POS.
+#   Rich API surface ideal for IDOR, BFLA, broken access control, and CORS testing.
+#   Home advantage: Indonesian-language flows, local payment patterns.
+#   No explicit automated-scanning ban found; stealth profile mandatory.
+#   SecBot strengths: auth flows, merchant dashboards, payment APIs, GraphQL probing.
+
+In Scope
+app.midtrans.com
+www.midtrans.com
+gopaymerchant.midtrans.com
+api.midtrans.com
+mokapos.com
+*.go-pay.co.id
+*.gopayapi.com
+*.gaming.gopayapi.com
+*.gofin.io
+*.findaya.com
+*.findaya.co.id
+*.gtflabs.io
+
+Out of Scope
+- Staging/sandbox environments (not listed by program)
+- Mobile apps (iOS/Android) — SecBot is web-only
+- Any GoTo Financial assets not listed above

--- a/scopes/neon.txt
+++ b/scopes/neon.txt
@@ -1,0 +1,21 @@
+# Program: Neon
+# Platform: HackerOne (hackerone.com/neon_bbp)
+# Bounty: $150 (low) – $3,000 (critical)
+# Notes: Serverless Postgres startup — storage/compute separated, autoscaling, DB branching.
+#   Went public March 2025 after 3-month private program + annual pentest (58 issues fixed).
+#   Both production and staging environments in scope.
+#   Researcher can register as a regular user to explore all platform flows.
+#   Tech stack: Rust (storage engine), TypeScript/Next.js (console), Go (control plane).
+#   SecBot strengths: console auth, project/branch isolation (IDOR), API key leakage,
+#     JWT security, SQL-injection in query endpoints, CORS on API.
+#   Focus: auth flows, multi-tenant isolation, API key management, data protection.
+
+In Scope
+console.neon.tech
+api.neon.tech
+neon.tech
+
+Out of Scope
+- GitHub repositories (source code bugs not in scope for web bounty)
+- DoS/availability attacks
+- Non-security-impactful configuration issues

--- a/scopes/paddle.txt
+++ b/scopes/paddle.txt
@@ -1,0 +1,32 @@
+# Program: Paddle.com
+# Platform: YesWeHack (yeswehack.com/programs/paddle-com-public-bug-bounty-program)
+# Bounty: $50 (low) – $5,000 (critical)
+# Notes: SaaS payments/billing platform serving 5,000+ software companies.
+#   Both production AND sandbox in scope — prefer sandbox for active testing.
+#   Sandbox provides full payment flows with Stripe test cards.
+#   CAUTION: "Automated scanners generating heavy traffic prohibited."
+#   → Always use stealth profile; rate-limit aggressively.
+#   SecBot strengths: vendor dashboard IDOR, billing API BFLA, auth bypass, CORS.
+#   Grey-box testing: researcher account available at sandbox-vendors.paddle.com.
+#   599 resolved reports — moderately picked over; focus on logic/access-control bugs.
+
+In Scope
+vendors.paddle.com
+sandbox-vendors.paddle.com
+api.paddle.com
+sandbox-api.paddle.com
+sandbox-checkout-service.paddle.com
+sandbox-buy.paddle.com
+paddle.net
+customer-portal.paddle.com
+login.paddle.com
+www.paddle.com
+developer.paddle.com
+
+Out of Scope
+- checkout-service.paddle.com (production checkout — sandbox only)
+- buy.paddle.com (production — sandbox only)
+- All other paddle.com subdomains not listed above
+- DoS/rate-limit bypass (explicitly out-of-scope per program rules)
+- Hidden UI features accessible via direct URL (by design)
+- MFA/email verification flows (by design)


### PR DESCRIPTION
## Summary

Bounty Scout run for 2026-05-25. Researched programs across HackerOne, YesWeHack, Intigriti, and Cyber Army Indonesia. Added 4 new targets, updated 1 existing scope file.

---

## New Targets

### 1. GoTo Financial — YesWeHack
- **Bounty:** $5–$7,000 | **Platform:** YesWeHack
- **Why it's a good fit:** Indonesia's largest fintech (GoPay + Midtrans + Moka POS). Rich API surface across payment processing, merchant dashboards, and wallet flows — ideal for SecBot's IDOR, BFLA, CORS, and broken-access-control checks. Home advantage: Indonesian-language auth flows, local OTP/PIN patterns.
- **Scope:** `app.midtrans.com`, `api.midtrans.com`, `gopaymerchant.midtrans.com`, `mokapos.com`, `*.go-pay.co.id`, `*.gopayapi.com`, `*.gofin.io`, `*.findaya.com`, `*.gtflabs.io`
- **Warning:** No explicit automated-scanning policy found in public sources. Stealth profile mandatory; keep RPS low.

### 2. Gojek — YesWeHack
- **Bounty:** $5–$5,000 | **Platform:** YesWeHack
- **Why it's a good fit:** Indonesian super-app with the widest web attack surface of any SEA program: ride-hailing, food delivery, and a large merchant portal. Dual platforms (also has legacy HackerOne program) but YesWeHack scope is more current. Home advantage. SecBot excels at merchant-portal IDOR, auth testing, and API CORS.
- **Scope:** `*.gojek.com`, `api.gojek.co.id`, `portal.gofoodmerchant.co.id`, `*.gofood.co.id`, `*.gobiz.co.id`, `*.gojekapi.com`, `*.golabs.io`
- **Warning:** No explicit automated-scanning policy found. Stealth profile mandatory.

### 3. Paddle.com — YesWeHack
- **Bounty:** $50–$5,000 | **Platform:** YesWeHack
- **Why it's a good fit:** SaaS billing/payments platform (5,000+ software company customers). Vendor dashboard + customer portal = great IDOR/BFLA surface. **Sandbox environment fully in scope** — safer active testing. Grey-box: register a researcher account at `sandbox-vendors.paddle.com`.
- **Scope:** `vendors.paddle.com`, `sandbox-vendors.paddle.com`, `api.paddle.com`, `sandbox-api.paddle.com`, `sandbox-checkout-service.paddle.com`, `customer-portal.paddle.com`, `login.paddle.com`, `paddle.net`
- **Warning:** Program rules explicitly prohibit "automated scanners generating heavy traffic." Always use stealth profile + aggressive rate limiting. Prefer sandbox for active tests. ~599 reports already resolved, so focus on logic/access-control bugs over low-hanging config issues.

### 4. Neon — HackerOne
- **Bounty:** $150–$3,000 | **Platform:** HackerOne (`hackerone.com/neon_bbp`)
- **Why it's a good fit:** Serverless Postgres startup (went public March 2025 after private run). Both production and **staging** in scope. Researcher can register as a real user — full auth flow testable. Tech stack: TypeScript/Next.js console + Rust storage + Go control plane. SecBot strengths: JWT security, multi-tenant IDOR (project/branch isolation), API key leakage, CORS on management API.
- **Scope:** `console.neon.tech`, `api.neon.tech`, `neon.tech`
- **Warning:** Specific automated-scanning policy not publicly documented; apply stealth profile as default.

---

## Existing Program Updates

### Cal.com — scope file updated
- Added HackerOne handle (`hackerone.com/cal_`) to the header for clarity.
- Noted that Cal.com announced going **closed-source in 2025**, citing AI-assisted exploit discovery as a security risk. Program appears still active as of 2026-05.
- Flagged `*.companyhub.com` scope entry for **manual verification** — unclear whether this is still a valid Cal.com-owned asset or stale data from initial setup.

---

## Programs Evaluated but Rejected

| Program | Platform | Reason Rejected |
|---|---|---|
| KOMOJU | YesWeHack | Explicit "no automated scanners" rule; also only staging domain in scope |
| BookBeat | YesWeHack | Explicit "refrain from using automated tools" rule |
| DANA (Indonesia) | YesWeHack | "Avoid automated tools" policy; scope is mainly mobile apps |
| Grafana Labs | Intigriti | Scope is OSS code/GitHub, not a live web app — wrong fit for SecBot |
| Lodgify | Intigriti | Invite-only program (requires manual email request); low avg payout (€269) |

---

## Platform Notes

- **HackerOne IBB reward cuts (May 2026):** HackerOne slashed Internet Bug Bounty (open-source fund) payouts by 75–89%. This affects Django, OpenSSL, etc. — **not** individual company programs like Moneybird or Cal.com, which manage their own bounty budgets.
- **Intigriti Spring Heist 2026:** Live hacking event June 12–26, up to €10,000 — worth monitoring separately.

## Test plan

- [ ] Verify `goto-financial.txt` scope domains resolve and are reachable
- [ ] Verify `gojek.txt` scope domains resolve and are reachable
- [ ] Verify `paddle.txt` — register researcher account on `sandbox-vendors.paddle.com` before first scan
- [ ] Verify `neon.txt` — register free account on `console.neon.tech` before first scan
- [ ] Manually confirm Cal.com `*.companyhub.com` scope via `hackerone.com/cal_` program page
- [ ] Run `secbot hunt --registry hunt-registry.yaml` dry-run to confirm 9 entries load correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_011MUwr7teeQBWj5Vh3c4T9Y)_