### PR TITLE
chore: update hunt registry — bounty scout [2026-06-01]

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -1,7 +1,9 @@
-# SecBot Hunt Registry — Diagnostic Run #1
-# Created: 2026-03-22
-# Purpose: First real bounty hunt — 5 carefully selected targets
+# SecBot Hunt Registry — Bounty Scout update 2026-06-01
+# Originally created: 2026-03-22 (Diagnostic Run #1)
+# Updated: 2026-06-01 — added 4 new targets, flagged calcom for re-verification
 # Strategy: low competition + web app depth + SecBot strengths
+
+# ── ORIGINAL 5 TARGETS ────────────────────────────────────────────────────────
 
 - name: kredivo
   platform: other
@@ -31,9 +33,53 @@
   schedule: weekly
   enabled: true
 
+# Cal.com went closed-source April 2026 citing AI scanners; verify H1 program
+# is still active before re-enabling. Paused until manually confirmed.
 - name: calcom
   platform: hackerone
   scope_file: scopes/calcom.txt
+  profile: stealth
+  schedule: weekly
+  enabled: false
+
+# ── NEW TARGETS (added 2026-06-01) ────────────────────────────────────────────
+
+# GoTo Financial — Indonesian fintech (GoPay / Midtrans / Moka POS)
+# YesWeHack · $5–$7,000 · payment APIs + merchant dashboards
+# SEA home-advantage, rich IDOR/CORS/JWT/SSRF surfaces
+- name: goto-financial
+  platform: yeswehack
+  scope_file: scopes/goto-financial.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+# WP Engine — WordPress hosting SaaS
+# Intigriti · €250–€2,500 · EXPLICIT automated scanning allowed (≤3 req/sec)
+# REQUIRED: set User-Agent to "Intigriti-<handle>" during scan
+- name: wpengine
+  platform: intigriti
+  scope_file: scopes/wpengine.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+# Monzo — UK neobank
+# Intigriti · £50–£12,500 · *.monzo.com wildcard · automated OK (≤2 req/sec)
+# NOTE: verify program is still active before first scan (VDP closed 2025)
+- name: monzo
+  platform: intigriti
+  scope_file: scopes/monzo.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+# KOMOJU — Japanese payment gateway (Degica)
+# YesWeHack · $50–$7,000 · dedicated staging env provided
+# WARNING: use stealth only — policy bars high-traffic automated scans
+- name: komoju
+  platform: yeswehack
+  scope_file: scopes/komoju.txt
   profile: stealth
   schedule: weekly
   enabled: true

--- a/scopes/calcom.txt
+++ b/scopes/calcom.txt
@@ -1,7 +1,13 @@
 # Program: Cal.com
 # Platform: HackerOne
 # Bounty: $100 - $3,000 (estimated)
-# Notes: Open-source scheduling (Next.js/TypeScript), code on GitHub, small startup
+# Notes: Scheduling SaaS (Next.js/TypeScript). IMPORTANT: Cal.com went closed-source
+#        in April 2026, citing AI-powered scanners as a security threat. The HackerOne
+#        program may have been updated or paused as a result.
+# ACTION REQUIRED: Verify program is still active at hackerone.com/calcom before
+#        scanning. If paused, disable this entry (enabled: false in registry).
+# WARNING: Cal.com explicitly cited automated AI scanners as a threat vector — extra
+#          care with stealth profile; respect any updated program rules.
 
 In Scope
 app.cal.com

--- a/scopes/goto-financial.txt
+++ b/scopes/goto-financial.txt
@@ -1,0 +1,24 @@
+# Program: GoTo Financial
+# Platform: YesWeHack
+# URL: https://yeswehack.com/programs/goto-financial-public-bounty-program
+# Bounty: $5 - $7,000
+# Notes: Indonesian fintech (GoPay, Midtrans payment gateway, Moka POS) — high priority
+#        for SEA/home-advantage edge. ~500-1000 employee org but sub-brands have
+#        smaller attack surfaces. Payment APIs + merchant dashboards = strong IDOR,
+#        CORS, SSRF, JWT surfaces. Automated scanning not explicitly prohibited.
+
+In Scope
+*.gopayapi.com
+*.go-pay.co.id
+gopaymerchant.midtrans.com
+mokapos.com
+*.gaming.gopayapi.com
+*.gofin.io
+*.findaya.com
+*.findaya.co.id
+*.gtflabs.io
+
+Out of Scope
+- Staging/test/integration environments
+- All other GoTo Financial assets not listed above
+- Mobile apps (Android/iOS) — focus scanner on web+API

--- a/scopes/komoju.txt
+++ b/scopes/komoju.txt
@@ -1,0 +1,20 @@
+# Program: KOMOJU
+# Platform: YesWeHack
+# URL: https://yeswehack.com/programs/komoju-public-bug-bounty-program
+# Bounty: $50 - $7,000
+# Notes: Japanese payment gateway (operated by Degica), supports JP/KR/EU payment
+#        methods. Provides a dedicated staging environment — test here, not prod.
+#        Merchant registration + KYC onboarding, admin dashboard (payments, refunds,
+#        user management), REST API + Hosted Page. Rich IDOR, auth, and API surfaces.
+# WARNING: Policy says "no automated scanners generating large amount of network
+#          traffic" — use stealth profile only. Low rate is fine per industry norms.
+
+In Scope
+https://yeswehack.staging.komoju.com
+https://doc.komoju.com/docs/fields-overview
+https://multipay.staging.test.komoju.com
+
+Out of Scope
+- All production komoju.com domains (test only on staging)
+- All domains/subdomains not listed above
+- Account squatting / registration abuse

--- a/scopes/monzo.txt
+++ b/scopes/monzo.txt
@@ -1,0 +1,32 @@
+# Program: Monzo
+# Platform: Intigriti
+# URL: https://app.intigriti.com/programs/monzobank/monzopublicbugbountyprogram/detail
+# Bounty: Low £50-£200 / Medium £125-£1,500 / High £325-£4,500 / Critical £500-£8,250
+#         Exceptional £850-£12,500 (Tier 1 rates)
+# Notes: UK neobank with wildcard *.monzo.com scope — login, dashboard, APIs.
+#        Automated scanning explicitly allowed at max 2 req/sec. High bounties
+#        (60% above industry average per Monzo). Rails-based backend likely.
+#        Researchers from 18 sanctioned countries cannot receive monetary bounties.
+# STATUS: Verify program is active before scanning — check Intigriti page first.
+#         (Note: VDP was closed in 2025; public bug bounty program should still be active.)
+
+# REQUIRED SCANNER CONFIG:
+# --profile stealth
+# Max rate: 2 req/sec
+
+In Scope (Tier 1 — highest payouts)
+*.monzo.com
+*.prod-ffs.io
+
+In Scope (Tier 3 — lower payouts)
+www.monzo.com
+monzo.com
+
+Out of Scope
+- P2P and contact discovery endpoints
+- *.monzo.me
+- community.monzo.com
+- Internal login/SSO systems (Okta, etc.)
+- Third-party integrations (Discourse, Mailgun, etc.)
+- Mobile apps (Android/iOS) — focus scanner on web+API
+- Public OAuth client secrets (intentionally public)

--- a/scopes/wpengine.txt
+++ b/scopes/wpengine.txt
@@ -1,0 +1,43 @@
+# Program: WP Engine
+# Platform: Intigriti
+# URL: https://app.intigriti.com/programs/wpengine/wpenginebugbounty/detail
+# Bounty: Low €250 / Medium €500 / High €1,000 / Critical €2,500
+# Notes: WordPress hosting SaaS — login dashboard, payments portal, and a suite of
+#        acquired products (ACF, Local by Flywheel, NitroPack). Explicitly allows
+#        automated scanning at max 3 req/sec. MUST set User-Agent header:
+#        "Intigriti-<your_handle>" — scanner will be blocked/banned otherwise.
+#        Tier 1 (my.wpengine.com, payments) pays highest; Tier 2 (product wildcards)
+#        pays medium.
+
+# REQUIRED SCANNER CONFIG:
+# --profile stealth
+# Custom User-Agent: Intigriti-<handle>
+# Max rate: 3 req/sec
+
+In Scope (Tier 1 — highest payouts)
+my.wpengine.com
+payments.wpengine.com
+wpengine.com
+app.getflywheel.com
+getflywheel.com
+
+In Scope (Tier 2 — medium payouts)
+*.advancedcustomfields.com
+*.localwp.com
+*.nitropack.io
+*.studiopress.com
+*.wpengine.io
+*.wpesvc.net
+*.deliciousbrains.com
+*.bettersearchreplace.com
+
+Out of Scope
+- Self-XSS without demonstrated multi-user impact
+- CORS misconfigurations on non-sensitive endpoints
+- Missing security headers and cookie flags (passive checks excluded)
+- CSRF with minimal/no demonstrable impact
+- Subdomain takeover reports without confirmed active takeover
+- Clickjacking without realistic user interaction chain
+- DoS / DDoS attacks
+- Email spoofing / SPF / DMARC issues
+- Username enumeration


### PR DESCRIPTION
## Bounty Scout — 2026-06-01

Automated registry update from the Bounty Scout agent. Researched new programs across HackerOne, Intigriti, YesWeHack, and Cyber Army Indonesia. Added 4 new targets and paused 1 existing target pending re-verification.

---

## New Targets Added

### 1. GoTo Financial (YesWeHack) ⭐ HIGH PRIORITY
- **Platform:** YesWeHack
- **Bounty:** $5 – $7,000
- **Scope:** `*.gopayapi.com`, `*.go-pay.co.id`, `gopaymerchant.midtrans.com`, `mokapos.com`, `*.gofin.io`, `*.findaya.com`, `*.gtflabs.io`
- **Why it's a good fit:** Indonesian fintech (GoPay + Midtrans payment gateway + Moka POS). SEA home-advantage — less competition than Western programs on the same platform. Payment APIs + merchant dashboards = strong IDOR, CORS, SSRF, JWT, and broken-access-control surfaces that align directly with SecBot's deepest checks. Bounty ceiling ($7k) is competitive.
- **Warnings:** Large company (GoTo Group), so expect some competition. Staging environments are explicitly out of scope — testing on production payment APIs requires care. Use stealth profile.

### 2. WP Engine (Intigriti)
- **Platform:** Intigriti
- **Bounty:** Low €250 / Medium €500 / High €1,000 / Critical €2,500
- **Scope (Tier 1):** `my.wpengine.com`, `payments.wpengine.com`, `wpengine.com`, `app.getflywheel.com`; also Tier 2 wildcards for ACF, LocalWP, NitroPack, StudioPress
- **Why it's a good fit:** WordPress hosting SaaS with a login portal, payments system, and multiple acquired sub-products. Critically, automated scanning is **explicitly allowed at ≤3 req/sec** — one of the few programs that directly permits SecBot-style testing. Multi-tenant PHP+WordPress stack is a good fit for SecBot's file-upload, SQLi, traversal, and access-control checks.
- **Warnings:** Must set `User-Agent: Intigriti-<handle>` on every request or scans will be flagged/blocked. CORS on non-sensitive endpoints, missing headers, and cookie-flag findings are explicitly excluded — suppress those in reports. Bounty ceiling is modest (€2,500) but lower competition.

### 3. Monzo (Intigriti)
- **Platform:** Intigriti
- **Bounty:** Medium £1,500 / High £4,500 / Critical £8,250 / Exceptional £12,500 (Tier 1)
- **Scope:** `*.monzo.com` wildcard (Tier 1), `*.prod-ffs.io` (Tier 1), `www.monzo.com` (Tier 3)
- **Why it's a good fit:** UK neobank with a wildcard scope — any subdomain of monzo.com is in-play. Automated scanning explicitly allowed at ≤2 req/sec. Bounties are 60% above industry average (per Monzo's own statement). Rails-like backend, rich authenticated user flows. SecBot's JWT, IDOR, CORS, and broken-access-control checks are well-suited.
- **Warnings:** High-profile program means more competition than other targets. Verify program is currently accepting submissions before the first scan — the VDP was closed in 2025 and the bug bounty program status should be confirmed at the Intigriti page. Researchers from 18 sanctioned countries cannot receive monetary rewards.

### 4. KOMOJU (YesWeHack)
- **Platform:** YesWeHack
- **Bounty:** $50 – $7,000
- **Scope:** `yeswehack.staging.komoju.com`, `doc.komoju.com/docs/fields-overview`, `multipay.staging.test.komoju.com`
- **Why it's a good fit:** Japanese payment gateway (Degica) operating in JP/KR/EU markets. Uniquely, KOMOJU provides a **dedicated staging environment** for testing — merchant registration/KYC flow, admin payment dashboard, REST API + Hosted Fields. Low competition (niche Japanese fintech, English-language program). SecBot's XSS, SQLi, IDOR, SSRF, and auth checks map well to the payment admin surface.
- **Warnings:** Automated scanners that generate "large amount of network traffic" are explicitly prohibited — stealth profile is mandatory. Production domains are entirely out of scope. Scope is limited to just 3 staging URLs, so coverage per scan will be narrow.

---

## Existing Target Changes

### Cal.com — PAUSED (`enabled: false`)
- **Reason:** Cal.com went closed-source on **April 15, 2026**, explicitly citing AI-powered automated scanners as the reason (a Gecko Security AI SAST engine found chained account-takeover vulnerabilities in January 2026). The HackerOne program may have been suspended, paused, or had its rules updated to prohibit automated tooling in response.
- **Action required:** Manually verify the HackerOne program is still active and review updated rules at `hackerone.com/calcom` before re-enabling. If confirmed active and automation is still permitted, flip `enabled: true`.

---

## Programs Researched but Not Added

| Program | Platform | Reason Skipped |
|---------|----------|----------------|
| Gojek | YesWeHack | Covered by GoTo Financial (same group); higher competition, mobile-heavy scope |
| Maya (PayMaya, Philippines) | YesWeHack | Explicitly bans automated scanners; API-only web scope (no web UI to crawl) |
| Paddle.com | YesWeHack | Bans automated scanners; production financial transactions out of scope; sandbox-only |
| Moneybird | HackerOne | Already in registry — no scope changes detected |
| OpenProject | YesWeHack | Already in registry — program still active with recent CVE reports in 2026 |
| Traveloka | Bugcrowd | Invite-only private program |
| Xendit | Self-hosted | VDP only, no monetary bounties |

---

## Test Plan
- [ ] Manually verify Cal.com HackerOne program status and re-enable if active
- [ ] Confirm Monzo Intigriti public bug bounty is currently accepting submissions
- [ ] For WP Engine: configure hunter handle in scan so `Intigriti-<handle>` user-agent is injected
- [ ] Run `secbot hunt --registry hunt-registry.yaml` on one new target (suggest GoTo Financial first) to validate scope file format


---
_Generated by [Claude Code](https://claude.ai/code/session_01FNcntKBQR3LufZ35yLcJh7)_