### PR TITLE
docs: bounty report drafts — 2026-06-13

### DIFF
--- a/bounty-pool/TRIAGE.md
+++ b/bounty-pool/TRIAGE.md
@@ -1,19 +1,20 @@
-# Bounty Pool Triage — Updated Mar 15, 2026 (Session 7)
+# Bounty Pool Triage — Updated 2026-06-13 (Session 8)
 
 ## Submission Priority
 
 ### TIER 1 — Submit (strongest signal)
 
 | # | Target | Finding | Severity | Notes |
-|---|--------|---------|----------|-------|
+|---|--------|---------|----------|---------|
 | 1 | indeed.com | CSRF cookie missing Secure on login page | Medium | Inconsistency between CSRF and INDEED_CSRF_TOKEN strengthens report. **CAVEAT:** Cookie set via JS, not HTTP header — curl won't reproduce. Needs Playwright/browser to verify. Submission draft ready: `2026-03-14-indeed-csrf-cookie-SUBMISSION.md` |
 
 ### TIER 2 — Hold (needs more work)
 
 | # | Target | Finding | Severity | Notes |
-|---|--------|---------|----------|-------|
+|---|--------|---------|----------|---------|
 | 2 | twitch.tv | server_session_id + api_token missing HttpOnly | Medium | HOLD — needs auth scan to verify these are actual auth tokens. Need Twitch account + login. |
 | 3 | bugcrowd.com | PathSession + FirstSession missing HttpOnly/Secure | Medium | Weak standalone — needs XSS chain to be credible. Submitting to their own program is bad optics. |
+| 4 | openproject | Session Fixation: _open_project_session not regenerated | Medium | Scan detected same session cookie pre/post login on `community.openproject.org/login?layout=1`. **CAVEAT:** Scanner had no credentials — POST without valid credentials = failed login = session regeneration not triggered. Need authenticated test to confirm. Community instance is fully patched — test against local Docker (see OPENPROJECT-CVE-ANALYSIS.md). |
 
 ### TIER 3 — Archived (non-bounty)
 
@@ -25,27 +26,84 @@ Moved to `bounty-pool/archived/`:
 ### OWN APPS — Fix These
 
 | # | Target | Finding | Severity | Notes |
-|---|--------|---------|----------|-------|
+|---|--------|---------|----------|---------|
 | A1 | finance.atmando.app | No rate limiting on /login and /graphql | HIGH | Brute-force risk on finance app. Add Cloudflare rate limiting + app-level throttle. |
 | A2 | finance.atmando.app | Missing HSTS header | MEDIUM | Middleware has HSTS configured but it's not appearing in response. Docker rebuild or middleware bug. |
 
-## Honest Assessment (Mar 15)
+---
 
-**Bounty readiness: LOW.** After 27+ targets scanned:
-- 0 critical/high vulnerabilities found on external targets
-- All findings are passive (headers, cookies) — no injection vulns
-- Cookie findings require browser reproduction (not curl-verifiable)
-- No authenticated scanning performed
+## Session 8 Analysis — March 26, 2026 Scans (Triaged 2026-06-13)
 
-**What actually worked:**
-- Finding real issues on our OWN app (rate limiting, HSTS)
-- 0% FP rate across all scans
-- Correctly identifying and filtering non-exploitable findings
+Three new v2 scans processed: **cal.com**, **neon.tech**, **openproject** (all 2026-03-26).
+Also reviewed: moneybird (2026-03-22).
 
-**Root cause unchanged:** Marketing sites + no auth + hardened targets = passive findings only.
+### Cal.com (HackerOne) — `scan-results/calcom-v2/secbot-2026-03-26T08-17-21-602Z.json`
+
+| Finding | Verdict | Reason |
+|---------|---------|--------|
+| `__Secure-next-auth.callback-url` missing HttpOnly | **FP** | Stores post-login redirect URL, not auth token. Not sensitive. |
+| Missing CSP on /signup | **Informational** | Auth pages (login) have nonce-CSP; /signup inconsistently missing. Not exploitable standalone, but noteworthy inconsistency. Not submittable without XSS proof. |
+| Missing HSTS on /administrator | **FP** | /administrator returns 404; 404 handler has different header set. |
+| Source Map Exposure on `_next/static/chunks/` | **FP** | Cal.com is MIT open source on GitHub. Source maps expose nothing not already public. |
+| Missing SRI for Intercom widget | **FP** | Third-party analytics/chat widget. SRI not applicable for CDN scripts that auto-update. |
+| Rate limiting on GET /auth/login, /login, /signup, /register, /forgot-password, /api/auth/session | **FP** | Scanner fires 15 GET requests at page-load endpoints. Rate limiting applies to POST auth submissions, not page loads. No POST credential test performed. |
+| OAuth missing state on /api/auth/session | **FP** | Wrong endpoint — `/api/auth/session` is NextAuth's current-session getter, not an OAuth authorization endpoint. |
+| Web Cache Deception via /admin/30min | **FP** | Response shows `cf-cache-status: DYNAMIC`. DYNAMIC = not cached by Cloudflare = WCD not exploitable. |
+
+### Neon.tech (NOT in hunt registry) — `scan-results/neon-v2/secbot-2026-03-26T13-22-18-825Z.json`
+
+**Note:** neon.tech is not in `hunt-registry.yaml`. Findings noted for completeness but no bounty action.
+
+| Finding | Verdict | Reason |
+|---------|---------|--------|
+| Open redirects via url/redirect/next/return/returnTo/redirect_uri/goto/dest params on /login | **FP** | Evidence: `Location: https://neon.com/login?url=...evil...` — redirect target is `neon.com` (same org), NOT `evil.example.com`. Scanner detects redirect parameter being forwarded, not an actual open redirect. |
+| `neon_consent` cookie missing HttpOnly/Secure | **FP** | `_consent` suffix = GDPR consent cookie. Consent widgets intentionally expose these to JS for state management. Classic FP pattern. |
+| Missing CSP on neon.com marketing page | **FP** | Marketing site homepage. Auto-rejected as informational by triagers. |
+| Missing HSTS on `neon.com/?chatId=1` | **FP** | Parameterized chat widget URL. If other pages have HSTS, this is a scanner artifact not a real gap. |
+| Missing SRI (24 external resources) | **FP** | 24 external scripts without SRI = common pattern for SaaS marketing sites. Not exploitable without a XSS vector. |
+| Verbose error on `/undefined` endpoint | **Artifact** | URL is literally "undefined" — JavaScript `undefined` leaking into a URL during crawl. Not a real endpoint. Response details are scanner noise, not real server error exposure. |
+
+### OpenProject (YesWeHack) — `scan-results/openproject-v2/secbot-2026-03-26T08-07-04-707Z.json`
+
+| Finding | Verdict | Reason |
+|---------|---------|--------|
+| Missing HSTS/CSP on /login.php | **FP** | OpenProject is a Rails app. `/login.php` → 404. 404 handler doesn't include security headers set on main app. Scanner is probing non-existent PHP page. |
+| Rate limiting on GET /login, /login?back_url=..., /login?layout=1 | **FP** | GET page-load probes only. Same false-positive as cal.com rate limit findings. |
+| Session Fixation: `_open_project_session` not regenerated | **HOLD** | Pre-login and post-login cookie values match. BUT: scanner had no credentials — failed login (no creds) = session not regenerated by design. Need authenticated test to confirm. Move to Tier 2. |
+
+### Moneybird (HackerOne) — `scan-results/moneybird/secbot-2026-03-22T12-37-45-339Z.json`
+
+| Finding | Verdict | Reason |
+|---------|---------|--------|
+| Missing CSP on www.moneybird.com | **FP** | Marketing homepage. Triagers auto-reject header findings on marketing pages. |
+| Mixed Content: http://www.moneybird.com/artikelen/ (and 10+ others) | **Informational** | Same-domain http:// href links on HTTPS page. If Moneybird has HSTS (they do), browser auto-upgrades. No actual insecure request made. Weak finding, likely informational. |
+
+---
+
+## Honest Assessment (Jun 2026, Session 8)
+
+**Bounty readiness: Still LOW.** Three more scans, same pattern:
+- 0 injection vulnerabilities found (XSS, SQLi, SSTI, SSRF, etc.)
+- All "high/medium" findings are passive (headers, cookies) — none submittable
+- Rate limiting findings are all GET-probe FPs
+- Open redirect findings are same-org redirect FPs
+- No authenticated scanning performed on any target
+
+**Root cause unchanged:** Unauthenticated scan + hardened targets = passive findings only.
+
+**Bright spot:** OpenProject CVE analysis (`OPENPROJECT-CVE-ANALYSIS.md`) documents 22 real CVEs
+with exact endpoints and payloads. The path forward is a local Docker test → authenticated scan.
+
+---
 
 ## Next Steps (Priority Order)
-1. **Fix own app issues** — rate limiting + HSTS on finance.atmando.app
-2. **Get test credentials** — Twitch account for auth scan, unlock T2 findings
-3. **Scan less-hardened targets** — community apps, smaller BBPs, OWASP Juice Shop
-4. **Indeed submission** — only if Dio confirms willingness (cookie is JS-set, reproduction tricky)
+
+1. **Submit Indeed finding** — CSRF cookie inconsistency. Only if Dio confirms willingness (cookie is JS-set, needs Playwright reproduction).
+2. **Authenticate Twitch** — Get Twitch account, run `secbot scan --auth-cookie` to unlock Tier 2 cookie findings.
+3. **OpenProject Docker test** — Spin up `openproject/openproject:16.6.2` (pre-patch), create two user accounts, run `secbot scan --auth ... --idor-alt-auth ...`. This is the highest-ROI next step.
+   - CVE-2026-27716 (`GET /api/v3/custom_fields/{id}/items`) — quick IDOR win
+   - CVE-2026-23646 (`DELETE /my/sessions/{id}`) — session IDOR
+   - CVE-2026-27731 (emoji reaction → internal comment leak) — reader-level IDOR
+   - CVE-2026-24685 (git rev argument injection → file write) — Critical RCE if repo enabled
+4. **Add neon.tech to hunt registry** — Neon has an active HackerOne program. App is PostgreSQL-as-a-service with real auth (console.neon.tech). Auth scan could find IDOR/BAC in API.
+5. **Fix own app** — rate limiting + HSTS on finance.atmando.app (unchanged from March).


### PR DESCRIPTION
## Summary

- Triaged 4 scan result files (calcom-v2, openproject-v2, neon-v2, moneybird) from March 2026
- Analyzed 31 medium/high severity findings across all 4 targets
- 0 new bounty reports drafted — all findings are FP or informational after root-cause review
- 1 new Tier 2 hold added: OpenProject session fixation (needs authenticated verification)

## What was found and why it's not submittable

| Root Cause | Findings | Count |
|-----------|---------|-------|
| GET-probe rate limit FPs (not POST auth tests) | cal.com + openproject login endpoints | 9 |
| Same-org redirect FPs (neon.tech → neon.com) | neon.tech open redirects | 8 |
| Open-source source map (cal.com is MIT) | cal.com source map exposure | 1 |
| Consent/analytics cookie FPs | neon_consent, third-party cookies | 3 |
| 404-page header absence (PHP on Rails, /administrator) | openproject + cal.com | 4 |
| Cloudflare DYNAMIC cache (WCD not exploitable) | cal.com WCD | 1 |
| Wrong OAuth endpoint probed | cal.com /api/auth/session | 1 |
| Marketing page headers (auto-rejected) | moneybird, neon.com | 2 |
| Third-party widget SRI (Intercom) | cal.com | 1 |
| Scanner crawl artifact (JS undefined in URL) | neon.tech /undefined | 1 |

## Highest-ROI next step

OpenProject local Docker testing using the 22-CVE test plan in `OPENPROJECT-CVE-ANALYSIS.md`. Four quick wins require only two user accounts and no special setup:
- CVE-2026-27716 (`GET /api/v3/custom_fields/{id}/items` — unauthenticated IDOR)
- CVE-2026-23646 (`DELETE /my/sessions/{id}` — session deletion IDOR)
- CVE-2026-27731 (emoji reaction leaks internal comments)
- CVE-2026-24685 (git rev `--output=` injection → Critical RCE)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GH4tVNWPFaYDitKDXq72o4)_