### PR TITLE
chore: update hunt registry — bounty scout [2026-06-15]

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -1,6 +1,6 @@
-# SecBot Hunt Registry — Diagnostic Run #1
+# SecBot Hunt Registry
 # Created: 2026-03-22
-# Purpose: First real bounty hunt — 5 carefully selected targets
+# Updated: 2026-06-15 — Bounty Scout added 4 new targets; fixed calcom scope (removed stale companyhub.com)
 # Strategy: low competition + web app depth + SecBot strengths
 
 - name: kredivo
@@ -34,6 +34,36 @@
 - name: calcom
   platform: hackerone
   scope_file: scopes/calcom.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+# --- New targets added 2026-06-15 (Bounty Scout) ---
+
+- name: ovo
+  platform: yeswehack
+  scope_file: scopes/ovo.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: superbank
+  platform: yeswehack
+  scope_file: scopes/superbank.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: barantum
+  platform: other
+  scope_file: scopes/barantum.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: mattermost
+  platform: bugcrowd
+  scope_file: scopes/mattermost.txt
   profile: stealth
   schedule: weekly
   enabled: true

--- a/scopes/barantum.txt
+++ b/scopes/barantum.txt
@@ -1,0 +1,19 @@
+# Program: Barantum
+# Platform: direct (no bug bounty platform)
+# Submission: bughunter@barantum.com
+# Bounty: Monetary — CVSS 3.1 severity-based, amounts not publicly listed
+# Notes: Largest CRM + Omnichannel Chat + Call Center SaaS in Indonesia (founded 2017,
+#        Bandung-based). Direct program means less competition and faster triage.
+#        Web-heavy application: CRM dashboard, omnichannel interface, call center panel, API.
+#        First reporter only. Employees and contractors ineligible.
+#        Warning: Small company — apply extra rate limiting (stealth profile required).
+# Strengths: XSS in CRM fields, IDOR in customer records, SQLi, CORS, broken access control
+
+In Scope
+barantum.com
+app.barantum.com
+
+Out of Scope
+- Social engineering, phishing
+- DoS/DDoS attacks
+- Physical access attacks

--- a/scopes/calcom.txt
+++ b/scopes/calcom.txt
@@ -2,10 +2,11 @@
 # Platform: HackerOne
 # Bounty: $100 - $3,000 (estimated)
 # Notes: Open-source scheduling (Next.js/TypeScript), code on GitHub, small startup
+# Note: companyhub.com is a separate, unrelated company (CRM SaaS with its own H1 VDP) — removed.
 
 In Scope
 app.cal.com
-*.companyhub.com
 
 Out of Scope
 - cal.com (marketing site only, not the app)
+- companyhub.com (different company entirely)

--- a/scopes/mattermost.txt
+++ b/scopes/mattermost.txt
@@ -1,0 +1,18 @@
+# Program: Mattermost
+# Platform: Bugcrowd
+# URL: https://bugcrowd.com/engagements/mattermost-mbb-public
+# Bounty: avg $327 recent (P1/P2 up to 2x bonus); 157 vulns rewarded since Nov 2024
+# Notes: Open-source team collaboration platform (Node.js + React + Go backend).
+#        Migrated from HackerOne to Bugcrowd Nov 2024; active with 75% of reports
+#        triaged within 11 days. Scope includes cloud webapp, REST API, and plugins.
+#        Good target for: auth bypass, IDOR in channel/team access, XSS in messages,
+#        CORS on API, info disclosure, rate limiting on login.
+#        Uses Bugcrowd Vulnerability Rating Taxonomy (P1–P4).
+
+In Scope
+mattermost.com
+
+Out of Scope
+- Self-hosted Mattermost instances (customer-deployed)
+- Third-party plugins not explicitly listed in the Bugcrowd scope
+- Mattermost's open-source GitHub repo (code-only, no running target)

--- a/scopes/ovo.txt
+++ b/scopes/ovo.txt
@@ -1,0 +1,17 @@
+# Program: OVO Indonesia
+# Platform: YesWeHack
+# URL: https://yeswehack.com/programs/ovo-bug-bounty-program
+# Bounty: Estimated €100 - €5,000+ (YesWeHack CVSS-based)
+# Notes: Indonesian fintech payment + rewards platform, backed by Grab. Launched public
+#        program Nov 2022. Primary product is mobile app but scope explicitly includes
+#        "most external-facing web assets." GCP-hosted infrastructure.
+#        Ineligible if you are current/former employee of OVO, Grab, GxS, GxB, or Superbank.
+# Strengths: CORS, open redirect, IDOR, info disclosure, XSS in web dashboard
+
+In Scope
+*.ovo.id
+
+Out of Scope
+- ovo.id marketing landing pages (focus on authenticated web app endpoints)
+- Mobile apps (iOS/Android)
+- Third-party services embedded in OVO app

--- a/scopes/superbank.txt
+++ b/scopes/superbank.txt
@@ -1,0 +1,17 @@
+# Program: Superbank
+# Platform: YesWeHack
+# URL: https://yeswehack.com/programs/superbank-public-bug-bounty-program
+# Bounty: Estimated €100 - €5,000+ (YesWeHack standard, verify on platform)
+# Notes: Indonesian OJK-licensed digital bank (rebranded from Bank Fama International, Feb 2023).
+#        Part of Grab/OVO/GxS/GxB ecosystem. Scope includes web banking view + API.
+#        Newer, less saturated program than OVO. Strong API + webview testing surface.
+#        Ineligible if current/former employee of Superbank, Grab, OVO, GxS, or GxB.
+# Strengths: IDOR in banking APIs, JWT, CORS, broken access control, CSRF
+
+In Scope
+superbank.id
+app.superbank.id
+
+Out of Scope
+- Mobile apps (iOS/Android)
+- Third-party payment integrations


### PR DESCRIPTION
## Summary

Weekly Bounty Scout run — 4 new targets added, 1 existing scope corrected.

---

## New Targets

### 1. OVO Indonesia — YesWeHack
- **Platform:** YesWeHack (`yeswehack.com/programs/ovo-bug-bounty-program`)
- **Bounty range:** ~€100–€5,000+ (CVSS-based)
- **Why:** Indonesian fintech payment platform backed by Grab. Public program since Nov 2022. Scope explicitly includes "most external-facing web assets" in addition to the mobile app. GCP infrastructure. Perfect match for SecBot's CORS, open redirect, IDOR, and XSS checks.
- **Warning:** Ineligible if you have worked at OVO, Grab, GxS, GxB, or Superbank.

### 2. Superbank — YesWeHack
- **Platform:** YesWeHack (`yeswehack.com/programs/superbank-public-bug-bounty-program`)
- **Bounty range:** ~€100–€5,000+ (verify on platform)
- **Why:** Indonesian OJK-licensed digital bank, rebranded from Bank Fama International in Feb 2023. Newer and less saturated than OVO. Part of the same Grab ecosystem. Scope covers web banking app + API + webview. Strong surface for IDOR in banking APIs, JWT, and broken access control.
- **Warning:** Same Grab-ecosystem employee exclusion as OVO.

### 3. Barantum — Direct program
- **Platform:** Direct email (`bughunter@barantum.com` — no platform)
- **Bounty range:** Monetary, CVSS 3.1-based (amounts not public)
- **Why:** Largest CRM + Omnichannel Chat + Call Center SaaS in Indonesia (Bandung, founded 2017). Direct submission means less competition and faster triage. Web-heavy application with CRM dashboard, omnichannel chat interface, call center panel. Great fit for XSS in form fields, IDOR in customer records, SQLi.
- **Warning:** Small company — stealth profile is critical. Use conservative rate limits.

### 4. Mattermost — Bugcrowd
- **Platform:** Bugcrowd (`bugcrowd.com/engagements/mattermost-mbb-public`)
- **Bounty range:** avg $327 recent (P1/P2 up to 2× bonus); 157 vulns rewarded since Nov 2024
- **Why:** Open-source team collaboration platform (Node.js + React + Go). Migrated from HackerOne to Bugcrowd Nov 2024. Active, 75% of reports triaged within 11 days. Good target for auth bypass, IDOR in channel/team access, XSS in messages, CORS on API, rate limit on login.

---

## Existing Scope Corrections

### `scopes/calcom.txt` — removed stale `*.companyhub.com`
- **Issue:** The scope file incorrectly listed `*.companyhub.com` as an in-scope target for Cal.com.
- **Reality:** CompanyHub is an entirely separate CRM SaaS company with its own HackerOne VDP (`hackerone.com/companyhub`). It has no relation to Cal.com.
- **Fix:** Removed `*.companyhub.com` from the Cal.com scope. The correct Cal.com target remains `app.cal.com`.

---

## Programs Researched but Skipped

| Program | Reason |
|---------|--------|
| Infomaniak (YesWeHack) | Explicitly prohibits automated scanning tools |
| Traveloka | Private Bugcrowd program — invite only |
| Grafana Labs (Intigriti) | Mostly OSS code review, less web app surface |
| Rocket.Chat (HackerOne) | VDP only — no monetary reward |
| Nextcloud | Ended bug bounty program (AI report flood) |
| Aikido Security (Intigriti) | Security-hardened app, high FP risk, low ROI |
| HackerOne Internet Bug Bounty | Program paused + major reward cuts (May 2026) |

---

## Scout notes
- HackerOne's Internet Bug Bounty program was paused in March 2026 and rewards were slashed in May 2026 (critical: $9,250 → $2,257). This affects open-source targets like Node.js but not private company programs.
- YesWeHack is gaining SEA traction — OVO + Superbank both live there. Worth monitoring for new Indonesian programs.
- Cyber Army Indonesia has programs but most are invite-only or government VDPs without monetary rewards. Not added.

https://claude.ai/code/session_01F3mjgsTXjsmsMsCjBuioVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3mjgsTXjsmsMsCjBuioVU)_