### PR TITLE
docs: bounty report drafts — 2026-06-24

### DIFF
--- a/bounty-pool/TRIAGE.md
+++ b/bounty-pool/TRIAGE.md
@@ -1,4 +1,4 @@
-# Bounty Pool Triage — Updated 2026-06-13 (Session 8)
+# Bounty Pool Triage — Updated 2026-06-24 (Session 9)
 
 ## Submission Priority
 
@@ -12,9 +12,10 @@
 
 | # | Target | Finding | Severity | Notes |
 |---|--------|---------|----------|-------|
-| 2 | twitch.tv | server_session_id + api_token missing HttpOnly | Medium | HOLD — needs auth scan to verify these are actual auth tokens. Need Twitch account + login. |
-| 3 | bugcrowd.com | PathSession + FirstSession missing HttpOnly/Secure | Medium | Weak standalone — needs XSS chain to be credible. Submitting to their own program is bad optics. |
-| 4 | openproject | Session Fixation: _open_project_session not regenerated | Medium | Scan detected same session cookie pre/post login on `community.openproject.org/login?layout=1`. **CAVEAT:** Scanner had no credentials — POST without valid credentials = failed login = session regeneration not triggered. Need authenticated test to confirm. Community instance is fully patched — test against local Docker (see OPENPROJECT-CVE-ANALYSIS.md). |
+| 2 | moneybird.com | DOM XSS via URL fragment on www.moneybird.com | High | Scanner (Playwright) observed URL fragment injected into 2 innerHTML sinks. Raw confidence was medium; AI promoted to high. **NEEDS BROWSER VERIFICATION** — visit `https://www.moneybird.com/#<img src=x onerror=alert(document.domain)>` and confirm alert fires. Draft: `bounty-pool/pending/moneybird/6d09cce8-dom-based-cross-site-scripting-(xss)-via-url-fragment.md` (improved 2026-06-24: fixed curl command, added verification checklist). |
+| 3 | twitch.tv | server_session_id + api_token missing HttpOnly | Medium | HOLD — needs auth scan to verify these are actual auth tokens. Need Twitch account + login. |
+| 4 | bugcrowd.com | PathSession + FirstSession missing HttpOnly/Secure | Medium | Weak standalone — needs XSS chain to be credible. Submitting to their own program is bad optics. |
+| 5 | openproject | Session Fixation: _open_project_session not regenerated | Medium | Scan detected same session cookie pre/post login on `community.openproject.org/login?layout=1`. **CAVEAT:** Scanner had no credentials — POST without valid credentials = failed login = session regeneration not triggered. Need authenticated test to confirm. Community instance is fully patched — test against local Docker (see OPENPROJECT-CVE-ANALYSIS.md). |
 
 ### TIER 3 — Archived (non-bounty)
 
@@ -73,37 +74,71 @@ Also reviewed: moneybird (2026-03-22).
 
 ### Moneybird (HackerOne) — `scan-results/moneybird/secbot-2026-03-22T12-37-45-339Z.json`
 
+**Correction from Session 8:** Session 8 only reviewed the 2 weakest findings (CSP + mixed content). The scan had 5 interpreted findings, including a DOM XSS and postMessage finding that were missed. Both reviewed here.
+
 | Finding | Verdict | Reason |
 |---------|---------|--------|
-| Missing CSP on www.moneybird.com | **FP** | Marketing homepage. Triagers auto-reject header findings on marketing pages. |
-| Mixed Content: http://www.moneybird.com/artikelen/ (and 10+ others) | **Informational** | Same-domain http:// href links on HTTPS page. If Moneybird has HSTS (they do), browser auto-upgrades. No actual insecure request made. Weak finding, likely informational. |
+| DOM XSS via URL fragment on www.moneybird.com | **HOLD** | Playwright detected URL fragment reaching 2 innerHTML sinks. Raw confidence medium. Draft improved — see Tier 2 entry. Needs browser verification before submit. |
+| Missing CSP on www.moneybird.com | **FP** | Marketing homepage. Triagers auto-reject header findings on marketing pages. Draft in pending/moneybird/ is companion to XSS but not standalone submittable. |
+| postMessage handlers missing origin check | **FP** | Handler snippet analysis reveals mouse event normalization code (`clientX`/`pageX`/`pageY`) — this is a minified JS event polyfill, not a real message processing sink. Classic scanner false positive. Draft `8c0823c1-postmessage-handlers.md` should NOT be submitted. |
+| Mixed Content: http://www.moneybird.com/artikelen/ (and 10+) | **Informational** | Same-domain http:// href links on HTTPS page. Moneybird has HSTS; browser auto-upgrades. No actual insecure request made. |
+| Race condition finding (info/low) | **FP** | Scan already marked this as false positive in interpretedFindings. |
 
 ---
 
-## Honest Assessment (Jun 2026, Session 8)
+## Session 9 Analysis — Kredivo + Moneybird Pending Review (Triaged 2026-06-24)
 
-**Bounty readiness: Still LOW.** Three more scans, same pattern:
-- 0 injection vulnerabilities found (XSS, SQLi, SSTI, SSRF, etc.)
-- All "high/medium" findings are passive (headers, cookies) — none submittable
-- Rate limiting findings are all GET-probe FPs
-- Open redirect findings are same-org redirect FPs
+Processed: **Kredivo** scan (2026-03-22, first triage ever) + review of **moneybird pending** drafts from previous sessions.
+
+### Kredivo (RedStorm) — `scan-results/kredivo/secbot-2026-03-22T12-37-39-601Z.json`
+
+Target: `blog.kredivo.com` (WordPress blog). In scope per `scopes/kredivo.txt`.
+
+| Finding | Verdict | Reason |
+|---------|---------|--------|
+| Exposed WordPress Login at /wp-login.php (high/high) | **FP** | Expected WordPress behavior on any WP installation. Programs treat this as informational — the login page existing is not a vulnerability; an exploited brute-force or auth bypass would be. Blog subdomain only. No exploit demonstrated. |
+| Missing CSP on blog.kredivo.com (high/high) | **FP** | Blog/marketing subdomain. CSP findings on blog pages are universally auto-rejected as informational by triagers. Not submittable standalone. |
+| Cookie `_hcc` missing HttpOnly/Secure (medium/high) | **FP** | `_hcc` is a HubSpot analytics/CRM cookie (standard prefix used by HubSpot's Conversations widget). Third-party tracking cookie explicitly identified in FP patterns guide. Set on blog page only, not auth surface. |
+
+**Kredivo verdict:** 0 submittable findings from this scan. Scan target (`blog.kredivo.com`) is a marketing blog, not the main app. **Need to re-scan `app.kredivo.com` and `mysandbox.kredivo.com`** — the sandbox domain is the highest-value target (purpose-built for security testing).
+
+### Moneybird Pending Files Review
+
+Files in `bounty-pool/pending/moneybird/`:
+
+| File | Status | Action |
+|------|--------|--------|
+| `6d09cce8-dom-based-cross-site-scripting-(xss)-via-url-fragment.md` | **IMPROVED** | Fixed curl command (curl cannot test DOM XSS). Added browser reproduction steps + verification checklist. Added raw confidence caveat. Moved to Tier 2. |
+| `09dd5267-missing-content-security-policy-header.md` | **FP — do not submit standalone** | Marketing page CSP. Only useful as a companion finding IF the DOM XSS is confirmed. Keep for context; do not submit alone. |
+| `8c0823c1-postmessage-handlers-missing-origin-validation.md` | **FP — do not submit** | Handler snippet is mouse event normalization code, not a real message sink. Would be triaged as N/A immediately. |
+
+---
+
+## Honest Assessment (Jun 2026, Session 9)
+
+**Bounty readiness: Still LOW, with one candidate worth manual verification.**
+
+- Kredivo blog scan: 0 findings, wrong target (blog ≠ app)
+- Moneybird: 1 plausible finding (DOM XSS) that needs 30 seconds of browser verification
 - No authenticated scanning performed on any target
+- No injection vulnerabilities confirmed by human yet
 
-**Root cause unchanged:** Unauthenticated scan + hardened targets = passive findings only.
-
-**Bright spot:** OpenProject CVE analysis (`OPENPROJECT-CVE-ANALYSIS.md`) documents 22 real CVEs
-with exact endpoints and payloads. The path forward is a local Docker test → authenticated scan.
+**First human-verifiable candidate in the pipeline:** The Moneybird DOM XSS (Tier 2) is the
+closest thing to a real finding. If the alert fires in a browser, that's a submittable High on
+an active H1 program. Takes 30 seconds to verify. Do it first.
 
 ---
 
 ## Next Steps (Priority Order)
 
-1. **Submit Indeed finding** — CSRF cookie inconsistency. Only if Dio confirms willingness (cookie is JS-set, needs Playwright reproduction).
-2. **Authenticate Twitch** — Get Twitch account, run `secbot scan --auth-cookie` to unlock Tier 2 cookie findings.
-3. **OpenProject Docker test** — Spin up `openproject/openproject:16.6.2` (pre-patch), create two user accounts, run `secbot scan --auth ... --idor-alt-auth ...`. This is the highest-ROI next step.
+1. **Verify Moneybird DOM XSS** — Open `https://www.moneybird.com/#<img src=x onerror=alert(document.domain)>` in a clean browser (no extensions). If alert fires → submit `6d09cce8` draft. 30-second task, highest ROI.
+2. **Re-scan kredivo app targets** — Run `secbot scan https://app.kredivo.com --profile stealth` and `secbot scan https://mysandbox.kredivo.com --profile stealth`. The sandbox domain is purpose-built for testing.
+3. **Submit Indeed finding** — CSRF cookie inconsistency. Only if Dio confirms willingness (cookie is JS-set, needs Playwright reproduction).
+4. **Authenticate Twitch** — Get Twitch account, run `secbot scan --auth-cookie` to unlock Tier 2 cookie findings.
+5. **OpenProject Docker test** — Spin up `openproject/openproject:16.6.2` (pre-patch), create two user accounts, run `secbot scan --auth ... --idor-alt-auth ...`. This is the highest-ROI next step.
    - CVE-2026-27716 (`GET /api/v3/custom_fields/{id}/items`) — quick IDOR win
    - CVE-2026-23646 (`DELETE /my/sessions/{id}`) — session IDOR
    - CVE-2026-27731 (emoji reaction → internal comment leak) — reader-level IDOR
    - CVE-2026-24685 (git rev argument injection → file write) — Critical RCE if repo enabled
-4. **Add neon.tech to hunt registry** — Neon has an active HackerOne program. App is PostgreSQL-as-a-service with real auth (console.neon.tech). Auth scan could find IDOR/BAC in API.
-5. **Fix own app** — rate limiting + HSTS on finance.atmando.app (unchanged from March).
+6. **Add neon.tech to hunt registry** — Neon has an active HackerOne program. App is PostgreSQL-as-a-service with real auth (console.neon.tech). Auth scan could find IDOR/BAC in API.
+7. **Fix own app** — rate limiting + HSTS on finance.atmando.app (unchanged from March).

--- a/bounty-pool/pending/moneybird/6d09cce8-dom-based-cross-site-scripting-(xss)-via-url-fragment.md
+++ b/bounty-pool/pending/moneybird/6d09cce8-dom-based-cross-site-scripting-(xss)-via-url-fragment.md
@@ -1,30 +1,112 @@
 # DOM-Based Cross-Site Scripting (XSS) via URL Fragment
 
-**Severity:** high | **CVSS:** 7 | CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+**Severity:** High | **CVSS:** 7.1 | CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
 **Platform:** HackerOne | **Program:** Moneybird
-**Confidence:** high
+**Status:** ⚠️ NEEDS HUMAN BROWSER VERIFICATION before submit
+**Scanner confidence:** medium (AI promoted to high — treat with caution)
+**CWE:** CWE-79 (Cross-site Scripting), CWE-116 (Improper Encoding / Escaping)
+**OWASP:** A03:2021 — Injection
 
-## Description
-The homepage directly writes URL fragment content into the DOM via innerHTML without sanitization. An attacker can craft a malicious URL containing an HTML/JS payload in the fragment (e.g., #<img src=x onerror=alert(1)>) and trick a user into clicking it, causing arbitrary JavaScript execution in the victim's browser.
+---
 
-## Steps to Reproduce
-1. Navigate to: https://www.moneybird.com/#<img src=x onerror=alert("secbot-xss-37")>
-2. Observe the alert dialog firing, confirming JavaScript execution
-3. The payload reaches at least two separate innerHTML sinks on the page
+## Summary
+
+The Moneybird homepage (`www.moneybird.com/`) appears to write URL fragment content
+into the DOM via `innerHTML` without sanitization. An attacker can craft a malicious link
+that causes arbitrary JavaScript to execute in the victim's browser — with no server-side
+interaction required, since URL fragments are processed entirely client-side.
+
+---
+
+## Reproduction Steps
+
+> **Important:** DOM-based XSS is triggered in the browser, not via HTTP request.
+> The curl command below only fetches the page HTML; it cannot trigger client-side JS.
+> **You must open the URL below in a real browser (Chrome / Firefox) to verify.**
+
+1. Open the following URL in a browser (paste directly into the address bar):
+
+   ```
+   https://www.moneybird.com/#<img src=x onerror=alert(document.domain)>
+   ```
+
+2. If an alert dialog appears showing `moneybird.com`, the XSS is confirmed.
+
+3. The scanner observed the payload reaching **2 separate `innerHTML` sinks** on the page,
+   which suggests the fragment is processed in multiple code paths.
+
+**Alternative payload (if angle brackets are encoded by browser):**
+
+```
+https://www.moneybird.com/#%3Cimg%20src%3Dx%20onerror%3Dalert(document.domain)%3E
+```
+
+---
+
+## Scanner Evidence
+
+```
+Detection method : dom-sink (Playwright)
+Payload          : #<img src=x onerror=alert("secbot-xss-37")>
+Sinks triggered  : innerHTML-set, innerHTML-set (2 occurrences)
+Test URL         : https://www.moneybird.com/#<img src=x onerror=alert("secbot-xss-37")>
+```
+
+> **Fetch the page HTML for reference (curl cannot trigger JS):**
+> ```bash
+> curl -sL 'https://www.moneybird.com/' | grep -i 'location.hash\|fragment\|innerHTML'
+> ```
+> If the page source contains `location.hash` or `window.location.hash` assigned to innerHTML,
+> that confirms the code path the scanner identified.
+
+---
 
 ## Impact
-An attacker can steal session cookies, perform actions on behalf of the user, redirect to phishing pages, or exfiltrate sensitive financial data visible in the Moneybird UI. This is particularly severe for an accounting/finance application.
+
+If confirmed, an attacker can:
+- Steal session cookies (if `HttpOnly` is not set on auth cookies)
+- Perform authenticated actions on behalf of the victim in the Moneybird accounting app
+- Redirect to phishing pages impersonating Moneybird
+- Exfiltrate sensitive financial data visible in the authenticated UI
+
+This is particularly impactful for an accounting SaaS: victims include accountants and business
+owners whose Moneybird session could be hijacked by clicking a malicious link (e.g., sent via
+email or shared as a "Moneybird invoice link").
+
+---
 
 ## Suggested Fix
-Never assign unsanitized URL fragment data to innerHTML. Use textContent for plain text, or sanitize with DOMPurify before any HTML insertion. Audit all code paths that read from window.location.hash.
 
-## Affected URLs
-- https://www.moneybird.com/
+Never assign unsanitized URL fragment content to `innerHTML`. Options:
 
-## Reproduction Command
-```bash
-curl \
-  -L \
-  -i \
-  'https://www.moneybird.com/#<img src=x onerror=alert("secbot-xss-37")>'
+```javascript
+// VULNERABLE
+document.getElementById('target').innerHTML = window.location.hash.slice(1);
+
+// SAFE — plain text only
+document.getElementById('target').textContent = window.location.hash.slice(1);
+
+// SAFE — if HTML rendering is genuinely required
+import DOMPurify from 'dompurify';
+document.getElementById('target').innerHTML = DOMPurify.sanitize(window.location.hash.slice(1));
 ```
+
+Audit all code paths that read from `window.location.hash` and ensure they use `textContent`
+or a sanitizer before any DOM insertion.
+
+---
+
+## Scope Note
+
+`www.moneybird.com` is covered by `moneybird.com` in the Moneybird HackerOne scope.
+Confirm the H1 policy includes the marketing site (not just `app.moneybird.com`) before submitting.
+
+---
+
+## Verification Checklist (for Dio before submitting)
+
+- [ ] Visited `https://www.moneybird.com/#<img src=x onerror=alert(document.domain)>` in browser
+- [ ] Alert dialog appeared with `www.moneybird.com`
+- [ ] Verified `www.moneybird.com` is explicitly in scope on H1 program page
+- [ ] Checked if any browser extension / ad blocker could have interfered with the test
+- [ ] Tested in a clean browser profile (no extensions)


### PR DESCRIPTION
## Summary

Session 9 triage run (2026-06-24). Processed first-ever Kredivo scan and reviewed unprocessed Moneybird pending files from previous sessions.

**Findings triaged: 6 total — 5 FP, 1 HOLD (needs browser verification)**

### Verdicts

| Target | Finding | Verdict |
|--------|---------|---------|
| Moneybird | DOM XSS via URL fragment on www.moneybird.com | **HOLD** — draft improved, needs 30s browser test |
| Moneybird | postMessage handlers on homepage | **FP** — handler is mouse-event polyfill, not a real sink |
| Moneybird | Missing CSP on marketing page | **FP** — standalone not submittable |
| Kredivo | Exposed wp-login.php on blog subdomain | **FP** — expected WordPress behavior, not exploited |
| Kredivo | Missing CSP on blog.kredivo.com | **FP** — blog/marketing page, auto-rejected |
| Kredivo | `_hcc` cookie missing HttpOnly/Secure | **FP** — HubSpot analytics cookie (third-party tracking) |

### Changes

**`bounty-pool/TRIAGE.md`**
- Header updated to Session 9 (2026-06-24)
- Added Moneybird DOM XSS to Tier 2 with verification instructions
- Added Session 9 analysis section: Kredivo triage + Moneybird pending review
- Corrected Session 8 moneybird section (had missed DOM XSS and postMessage findings)
- Updated Next Steps: Moneybird XSS browser check is now #1 priority (30s task)

**`bounty-pool/pending/moneybird/6d09cce8-dom-based-cross-site-scripting-(xss)-via-url-fragment.md`**
- Removed misleading `curl` command (curl cannot trigger DOM XSS via fragment)
- Added proper browser-based reproduction steps with two payload variants
- Added human verification checklist before submit
- Added scope note (verify www.moneybird.com is in H1 scope, not just app.moneybird.com)
- Added raw confidence caveat (scanner original confidence was medium, AI promoted to high)

## Action Required

**Before merging, Dio should:** Open `https://www.moneybird.com/#``&lt;img src=x onerror=alert(document.domain)&gt;'`` in a clean browser (no extensions). If an alert fires → draft is ready to submit to HackerOne. If no alert → downgrade to FP.

## Next Steps (from TRIAGE.md)
1. Verify Moneybird DOM XSS in browser (30 seconds)
2. Re-scan `app.kredivo.com` + `mysandbox.kredivo.com` — the blog was the wrong target
3. Submit Indeed CSRF cookie finding (Tier 1, draft ready)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N91NNmsrrxMBUWNyMdvu3z)_