### PR TITLE
chore: update hunt registry — bounty scout 2026-07-13

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -1,7 +1,14 @@
-# SecBot Hunt Registry — Diagnostic Run #1
+# SecBot Hunt Registry
 # Created: 2026-03-22
-# Purpose: First real bounty hunt — 5 carefully selected targets
+# Updated: 2026-07-13 (Bounty Scout — added 3 new targets)
 # Strategy: low competition + web app depth + SecBot strengths
+#
+# NOTE (2026-07-13): HackerOne's Internet Bug Bounty (IBB) program was paused and
+# payouts were slashed 75-89% in May 2026 due to AI-flooding of submissions. This
+# affects OPEN-SOURCE programs on IBB (Node.js, etc.) but NOT individual company
+# programs like moneybird and calcom — those set their own bounty tables.
+
+# ─── Original 5 targets ───────────────────────────────────────────────────────
 
 - name: kredivo
   platform: other
@@ -37,3 +44,32 @@
   profile: stealth
   schedule: weekly
   enabled: true
+
+# ─── Added 2026-07-13 (Bounty Scout) ─────────────────────────────────────────
+
+- name: gojek
+  platform: yeswehack
+  scope_file: scopes/gojek.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  # Indonesian super-app. High priority: home advantage + massive API surface.
+  # Must add unique header to all requests (e.g. X-SecBot-ID: <uuid>).
+
+- name: paddle
+  platform: yeswehack
+  scope_file: scopes/paddle.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  # Payment SaaS. Test on sandbox-* domains for payment flows.
+  # Keep request volume low — high-traffic automated scanning explicitly prohibited.
+
+- name: aiven
+  platform: bugcrowd
+  scope_file: scopes/aiven.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+  # Cloud data SaaS. Highest bounty ceiling in registry (up to $25k).
+  # Focus: tenant isolation, IDOR between service instances, SSRF into cloud metadata.

--- a/scopes/aiven.txt
+++ b/scopes/aiven.txt
@@ -1,0 +1,23 @@
+# Program: Aiven Managed Bug Bounty
+# Platform: Bugcrowd
+# Program URL: https://bugcrowd.com/engagements/aiven-mbb-og
+# Bounty: up to $25,000 (estimated: Critical $10,000-$25,000, High $3,000-$10,000)
+# Notes: Cloud data infrastructure SaaS (managed Kafka, PostgreSQL, Redis, OpenSearch, etc.)
+#        Finnish company ~500 employees. Console app + REST API in scope. Tech-savvy user base
+#        so IDOR between service instances, broken tenant isolation, JWT/auth bypass, and
+#        SSRF into internal cloud metadata are highest value. Moderately competitive.
+#        Last verified: 2026-07-13
+
+In Scope
+console.aiven.io
+api.aiven.io
+aiven.io
+regatta.aiven.io
+
+Out of Scope
+- Managed service infrastructure (cloud provider VMs, Kafka brokers, etc.)
+- Social engineering or phishing
+- DDoS / availability attacks
+- Third-party dependencies not maintained by Aiven
+- Issues requiring physical access
+- Scanner-generated reports without manual validation

--- a/scopes/gojek.txt
+++ b/scopes/gojek.txt
@@ -1,0 +1,40 @@
+# Program: Gojek (PT GoTo Gojek Tokopedia Tbk)
+# Platform: YesWeHack
+# Program URL: https://yeswehack.com/programs/gojek-bug-bounty-program
+# Bounty: $5 - $5,000 (Critical ~$5,000, High ~$2,000, Medium ~$500, Low ~$5)
+# Notes: Indonesian super-app (ride-hailing, food delivery, payments, merchant). Massive
+#        web + API scope across multiple subsidiaries. Stealth required. Must include a
+#        unique HTTP request header (e.g. X-SecBot-ID) to separate testing traffic.
+#        IDOR, broken access control, SSRF, and payment API logic bugs are highest value.
+#        Last verified: 2026-07-13
+
+In Scope
+*.gojek.com
+api.gojek.co.id
+gofood.co.id
+*.gofood.co.id
+portal.gofoodmerchant.co.id
+*.gofoodmerchant.co.id
+api.gobiz.co.id
+*.gobiz.co.id
+*.gojekapi.com
+*.gopayapi.com
+*.go-pay.co.id
+midtrans.com
+api.midtrans.com
+app.midtrans.com
+mokapos.com
+*.gofin.io
+*.findaya.com
+*.findaya.co.id
+*.gtflabs.io
+*.golabs.io
+
+Out of Scope
+- Mobile app binary analysis
+- Third-party services not operated by Gojek/GoTo
+- Social engineering
+- Physical security
+- DDoS / availability testing
+- Findings solely from automated scanner output without manual validation
+- Rate-limiting bypasses without demonstrated impact

--- a/scopes/paddle.txt
+++ b/scopes/paddle.txt
@@ -1,0 +1,34 @@
+# Program: Paddle.com
+# Platform: YesWeHack
+# Program URL: https://yeswehack.com/programs/paddle-com-public-bug-bounty-program
+# Bounty: $50 - $5,000 (estimated per severity)
+# Notes: UK payment infrastructure SaaS (merchant-of-record, subscriptions, billing).
+#        Sandbox environment is in scope and preferred for payment flow testing.
+#        Automated scanners that generate large traffic volumes are PROHIBITED — use
+#        stealth profile only. Financial transaction tests must be on sandbox, not prod.
+#        Sandbox and production share the same codebase, so sandbox findings apply.
+#        Good SecBot targets: vendor portal auth, customer portal, API auth, CORS, JWT.
+#        Last verified: 2026-07-13
+
+In Scope
+vendors.paddle.com
+sandbox-vendors.paddle.com
+api.paddle.com
+sandbox-api.paddle.com
+sandbox-checkout-service.paddle.com
+sandbox-buy.paddle.com
+customer-portal.paddle.com
+login.paddle.com
+sandbox-login.paddle.com
+developer.paddle.com
+paddle.net
+
+Out of Scope
+- paddle.com (marketing site)
+- Automated scanners generating high request volumes (stealth mode required)
+- Payment card data or live financial transactions on production
+- Third-party payment processors
+- Social engineering
+- DDoS / availability attacks
+- Issues requiring physical access
+- XSS Hunter or third-party OOB tools (self-hosted allowed)


### PR DESCRIPTION
## Summary

Bounty Scout agent run for 2026-07-13. Researched new programs across HackerOne, Bugcrowd, YesWeHack, and Cyber Army Indonesia. Added 3 new targets; skipped 3 candidates with disqualifying policies.

---

## New Targets Added

### 1. Gojek — YesWeHack · `$5–$5,000`
- **Fit:** Indonesian super-app (ride-hail, food delivery, payments, merchant). Highest priority due to home advantage + low competition from Western researchers + massive API surface.
- **Scope:** `*.gojekapi.com`, `api.gojek.co.id`, `gofood.co.id`, `*.gobiz.co.id`, `*.gofoodmerchant.co.id`, `midtrans.com`, `app.midtrans.com`, `mokapos.com`, `*.go-pay.co.id`, `*.gojek.com`
- **SecBot strengths aligned:** IDOR between merchant/user accounts, broken access on payment APIs, SSRF into internal fintech infrastructure, auth bypass on GoBiz merchant portal
- **Warning:** Must include a unique HTTP header (e.g. `X-SecBot-ID: <uuid>`) in every request to separate testing traffic. Stealth profile mandatory.

### 2. Paddle — YesWeHack · `$50–$5,000`
- **Fit:** UK payment-infrastructure SaaS (merchant-of-record, subscriptions, billing). Vendor portal + customer portal + sandbox env all in scope. Sandbox and production share the same codebase.
- **Scope:** `vendors.paddle.com`, `sandbox-vendors.paddle.com`, `api.paddle.com`, `sandbox-api.paddle.com`, `customer-portal.paddle.com`, `login.paddle.com`, `developer.paddle.com`
- **SecBot strengths aligned:** Vendor portal auth bypass, customer portal IDOR, JWT security on API, CORS on checkout endpoints, CSRF on subscription management
- **Warning:** High-traffic automated scanning explicitly prohibited. Stealth profile mandatory. Payment flow tests must target sandbox-* domains only.

### 3. Aiven — Bugcrowd · up to `$25,000`
- **Fit:** Cloud data-as-a-service (managed Kafka, PostgreSQL, Redis, OpenSearch). Finnish company ~500 employees. Highest bounty ceiling in the registry. Less competition than AWS/GCP equivalents.
- **Scope:** `console.aiven.io`, `api.aiven.io`, `aiven.io`, `regatta.aiven.io`
- **SecBot strengths aligned:** Tenant isolation / IDOR between service instances, SSRF into cloud metadata endpoints (AWS/GCP/Azure), broken access control on project/org management, info disclosure in API error responses
- **Warning:** Moderately competitive — technical audience means some researchers already test here. Focus on business-logic and multi-tenant isolation bugs that scanners miss.

---

## Existing Target Status

| Target | Platform | Status | Notes |
|--------|----------|--------|-------|
| kredivo | RedStorm | ✅ Active | No changes. Medium bounty (~$32) is below $100 threshold but critical (~$190) still worthwhile as Indonesian fintech priority. |
| anytask | Bugcrowd | ✅ Active | No changes. Staging domain still in scope. |
| moneybird | HackerOne | ✅ Active | HackerOne IBB payout cuts (May 2026) affect open-source IBB programs only — Moneybird sets its own bounty table, not impacted. |
| openproject | YesWeHack | ✅ Active | Still EU Commission funded. OpenProject 16.6.3 released Dec 2025 with bug bounty fixes, meaning active scope. |
| calcom | HackerOne | ✅ Active | HackerOne IBB cuts do not apply (individual company program). |

---

## Candidates Skipped

| Program | Reason |
|---------|--------|
| **Infomaniak** (YesWeHack, €100–€7,000) | Explicitly prohibits automated scanners — incompatible with SecBot |
| **BlaBlaCar** (YesWeHack, €50–€3,000) | Program rules reject automated scanner reports that haven't been manually validated; high triager skepticism |
| **Alasco** (YesWeHack, $50–€1,000) | Max bounty too low ($1,000) relative to effort; niche construction-tech SaaS |

---

## Platform Intelligence Note

HackerOne's Internet Bug Bounty (IBB) program paused submissions and slashed payouts 75–89% in May 2026 due to AI-assisted report flooding overwhelming open-source maintainers' remediation capacity. **This does not affect individual company programs** like Moneybird and Cal.com (those set their own bounty tables). Trend to watch: programs on YesWeHack and Bugcrowd are absorbing researcher traffic that previously went to H1 IBB.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh8JDnjAHUXKysPPRP1EHr)_