### PR TITLE
chore: update hunt registry — bounty scout [2026-07-27]

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -1,6 +1,6 @@
-# SecBot Hunt Registry — Diagnostic Run #1
+# SecBot Hunt Registry
 # Created: 2026-03-22
-# Purpose: First real bounty hunt — 5 carefully selected targets
+# Updated: 2026-07-27 (Bounty Scout run)
 # Strategy: low competition + web app depth + SecBot strengths
 
 - name: kredivo
@@ -24,16 +24,41 @@
   schedule: weekly
   enabled: true
 
+# DISABLED 2026-07-27: Program ended June 2026 (EU Commission sponsorship concluded)
 - name: openproject
   platform: other
   scope_file: scopes/openproject.txt
   profile: stealth
   schedule: weekly
-  enabled: true
+  enabled: false
 
+# DISABLED 2026-07-27: Policy explicitly prohibits automated scanners on infrastructure
 - name: calcom
   platform: hackerone
   scope_file: scopes/calcom.txt
+  profile: stealth
+  schedule: weekly
+  enabled: false
+
+# --- NEW 2026-07-27 ---
+
+- name: goto-financial
+  platform: yeswehack
+  scope_file: scopes/goto-financial.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: gojek
+  platform: yeswehack
+  scope_file: scopes/gojek.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+- name: mattermost
+  platform: bugcrowd
+  scope_file: scopes/mattermost.txt
   profile: stealth
   schedule: weekly
   enabled: true

--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -47,6 +47,7 @@
   scope_file: scopes/goto-financial.txt
   profile: stealth
   schedule: weekly
+  extra_args: '--auth-header "X-Bug-Bounty: secbot-hunt"'
   enabled: true
 
 - name: gojek
@@ -54,6 +55,7 @@
   scope_file: scopes/gojek.txt
   profile: stealth
   schedule: weekly
+  extra_args: '--auth-header "X-Bug-Bounty: secbot-hunt"'
   enabled: true
 
 - name: mattermost

--- a/scopes/calcom.txt
+++ b/scopes/calcom.txt
@@ -1,5 +1,8 @@
 # Program: Cal.com
 # Platform: HackerOne
+# STATUS: DISABLED — Policy explicitly prohibits automated scanners on infrastructure/dashboard
+#         ("asks that automated scanners not be run on their infrastructure or dashboard")
+#         Researchers must contact Cal.com to set up a sandbox before any automated testing.
 # Bounty: $100 - $3,000 (estimated)
 # Notes: Open-source scheduling (Next.js/TypeScript), code on GitHub, small startup
 

--- a/scopes/gojek.txt
+++ b/scopes/gojek.txt
@@ -1,0 +1,25 @@
+# Program: GOJEK
+# Platform: YesWeHack
+# Bounty: $5 - $5,000
+# URL: https://yeswehack.com/programs/gojek-bug-bounty-program
+# Notes: Indonesian super-app (ride-hailing, GoFood, GoBiz merchant portal). 12 scopes
+#        with wide wildcard coverage. YesWeHack policy requires a unique string/header on
+#        all requests from tools — configure SecBot with a custom header (X-Bug-Bounty or
+#        similar) when scanning. <1 day first response time. 683 reports submitted so far;
+#        focus on less-tested API endpoints and merchant flows for better hit rate.
+
+In Scope
+api.gojek.co.id
+*.gojek.com
+gofood.co.id
+*.gofood.co.id
+api.gobiz.co.id
+*.gobiz.co.id
+portal.gofoodmerchant.co.id
+*.gofoodmerchant.co.id
+*.gojekapi.com
+*.golabs.io
+
+Out of Scope
+- Mobile-only apps (target web/API surfaces)
+- Any domain not explicitly listed above

--- a/scopes/gojek.txt
+++ b/scopes/gojek.txt
@@ -9,13 +9,13 @@
 #        focus on less-tested API endpoints and merchant flows for better hit rate.
 
 In Scope
+gofood.co.id
+portal.gofoodmerchant.co.id
 api.gojek.co.id
 *.gojek.com
-gofood.co.id
 *.gofood.co.id
 api.gobiz.co.id
 *.gobiz.co.id
-portal.gofoodmerchant.co.id
 *.gofoodmerchant.co.id
 *.gojekapi.com
 *.golabs.io

--- a/scopes/goto-financial.txt
+++ b/scopes/goto-financial.txt
@@ -8,15 +8,15 @@
 #        to tag SecBot traffic per YesWeHack/GoTo testing policy.
 
 In Scope
+app.midtrans.com
+midtrans.com
+gopaymerchant.midtrans.com
+api.midtrans.com
+mokapos.com
 *.gofin.io
 *.go-pay.co.id
 *.gopayapi.com
 *.gaming.gopayapi.com
-midtrans.com
-app.midtrans.com
-api.midtrans.com
-gopaymerchant.midtrans.com
-mokapos.com
 
 Out of Scope
 - Mobile-only apps (target web/API surfaces)

--- a/scopes/goto-financial.txt
+++ b/scopes/goto-financial.txt
@@ -1,0 +1,23 @@
+# Program: GoTo Financial
+# Platform: YesWeHack
+# Bounty: $5 - $7,000
+# URL: https://yeswehack.com/programs/goto-financial-public-bounty-program
+# Notes: Indonesian fintech super-app (GoPay, Midtrans payment gateway). Wide wildcard scope
+#        covering payment APIs, merchant dashboards, and financial services. 14 scopes,
+#        <1 day first response. Use stealth profile; include a unique X-Bug-Bounty header
+#        to tag SecBot traffic per YesWeHack/GoTo testing policy.
+
+In Scope
+*.gofin.io
+*.go-pay.co.id
+*.gopayapi.com
+*.gaming.gopayapi.com
+midtrans.com
+app.midtrans.com
+api.midtrans.com
+gopaymerchant.midtrans.com
+mokapos.com
+
+Out of Scope
+- Mobile-only apps (target web/API surfaces)
+- Any domain not explicitly listed above

--- a/scopes/mattermost.txt
+++ b/scopes/mattermost.txt
@@ -1,0 +1,16 @@
+# Program: Mattermost
+# Platform: Bugcrowd
+# Bounty: ~$150 - $3,000 (estimated; Bugcrowd managed program)
+# URL: https://bugcrowd.com/engagements/mattermost-mbb-public
+# Notes: Open-source team messaging platform (Node.js/React). Moved from HackerOne to
+#        Bugcrowd in November 2024 with expanded scope. Good fit for: XSS (message rendering,
+#        OAuth endpoints), CORS, CSRF, broken access control. Focus on the cloud-hosted
+#        service (mattermost.com) and newly added plugin scopes rather than self-hosted.
+
+In Scope
+mattermost.com
+*.mattermost.com
+
+Out of Scope
+- Self-hosted Mattermost instances (customer-operated)
+- github.com/mattermost (code review, not runtime testing)

--- a/scopes/openproject.txt
+++ b/scopes/openproject.txt
@@ -1,6 +1,7 @@
 # Program: OpenProject
 # Platform: YesWeHack
-# Bounty: EUR 100 - EUR 5,000
+# STATUS: ENDED — Program concluded June 2026 (EU Commission sponsorship finished)
+# Bounty: EUR 100 - EUR 5,000 (was)
 # Notes: Open-source project management (Rails + Angular), code on GitHub, EU Commission funded
 
 In Scope

--- a/src/hunting/registry.ts
+++ b/src/hunting/registry.ts
@@ -6,7 +6,14 @@ function snakeToCamel(key: string): string {
 }
 
 function stripQuotes(value: string): string {
-  return value.replace(/^["']|["']$/g, '').trim();
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
 }
 
 export function parseRegistry(content: string): Program[] {
@@ -63,8 +70,19 @@ function buildProgram(raw: Record<string, string>): Program {
   if (raw['auth']) program.auth = raw['auth'];
   if (raw['lastScan']) program.lastScan = raw['lastScan'];
   if (raw['enabled'] !== undefined) program.enabled = raw['enabled'] !== 'false';
+  if (raw['extraArgs']) program.extraArgs = parseShellArgs(raw['extraArgs']);
 
   return program;
+}
+
+function parseShellArgs(raw: string): string[] {
+  const tokens: string[] = [];
+  const re = /(?:"([^"]*)")|(?:'([^']*)')|(\S+)/g;
+  let match;
+  while ((match = re.exec(raw)) !== null) {
+    tokens.push(match[1] ?? match[2] ?? match[3] ?? '');
+  }
+  return tokens.filter(Boolean);
 }
 
 const SCHEDULE_DAYS: Record<Schedule, number> = {

--- a/src/hunting/types.ts
+++ b/src/hunting/types.ts
@@ -10,6 +10,7 @@ export interface Program {
   auth?: string;
   lastScan?: string;
   enabled?: boolean;
+  extraArgs?: string[];
 }
 
 export interface EscalationItem {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1639,6 +1639,7 @@ program
       args.push('-o', join(homedir(), '.secbot', 'results', prog.name));
       args.push('-y'); // auto-consent for non-interactive
       if (prog.auth) args.push('-a', resolve(prog.auth));
+      if (prog.extraArgs?.length) args.push(...prog.extraArgs);
 
       // Run scan as child process
       const { execFile } = await import('node:child_process');

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -79,6 +79,17 @@ describe('parseRegistry', () => {
     const programs = parseRegistry(content);
     expect(programs[0].lastScan).toBe('2026-01-01T00:00:00.000Z');
   });
+
+  it('parses extra_args with a quoted value into a string array', () => {
+    const content = `programs:\n  - name: "With Header"\n    platform: yeswehack\n    scope_file: ./scope\n    profile: stealth\n    schedule: weekly\n    extra_args: --auth-header "X-Bug-Bounty: secbot-hunt"\n`;
+    const programs = parseRegistry(content);
+    expect(programs[0].extraArgs).toEqual(['--auth-header', 'X-Bug-Bounty: secbot-hunt']);
+  });
+
+  it('leaves extraArgs undefined when extra_args is absent', () => {
+    const programs = parseRegistry(VALID_REGISTRY);
+    expect(programs[0].extraArgs).toBeUndefined();
+  });
 });
 
 describe('isDue', () => {


### PR DESCRIPTION
## Summary

Automated Bounty Scout run — 2026-07-27. Disabled 2 stale targets, added 3 new ones.

---

## Disabled targets

### ❌ openproject (YesWeHack)
**Reason:** Program concluded June 2026 — the EU Commission sponsorship that funded it has ended. YesWeHack and OpenProject confirmed the program is closed. No further submissions will be rewarded.

### ❌ calcom (HackerOne)
**Reason:** Cal.com's policy explicitly states: *"asks that automated scanners not be run on their infrastructure or dashboard — researchers must contact Cal.com to set up a sandbox."* This is incompatible with SecBot's automated scanning approach. Running SecBot against their live app would violate program rules and risk report rejection or banning.

---

## New targets

### ✅ goto-financial (YesWeHack) — $5–$7,000
- **Company:** GoTo Financial (GoPay, Midtrans payment gateway) — Indonesian fintech
- **Platform:** YesWeHack — `https://yeswehack.com/programs/goto-financial-public-bounty-program`
- **Scope:** `*.gofin.io`, `*.go-pay.co.id`, `*.gopayapi.com`, `midtrans.com`, `app.midtrans.com`, `api.midtrans.com`, merchant portals
- **Why it's a good fit:** Wide wildcard API scope on a payment platform — perfect for JWT auth bypass, CORS misconfig, CSRF on payment flows, SSRF via merchant webhooks, broken access control (IDOR on financial records). Indonesian company = home-field advantage + lower competition from Western researchers.
- **Stats:** 14 scopes, 568 reports submitted, <1 day first-response time. Last updated May 2026 (program actively maintained).
- **Warning:** Use stealth profile. Include a unique identification header (e.g. `X-Bug-Bounty: secbot`) in all requests per YesWeHack/GoTo testing policy.

### ✅ gojek (YesWeHack) — $5–$5,000
- **Company:** GOJEK — Indonesian super-app (ride-hailing, GoFood, GoBiz merchant portal)
- **Platform:** YesWeHack — `https://yeswehack.com/programs/gojek-bug-bounty-program`
- **Scope:** `api.gojek.co.id`, `*.gojek.com`, `*.gofood.co.id`, `*.gobiz.co.id`, `*.gofoodmerchant.co.id`, `*.gojekapi.com`, `*.golabs.io`
- **Why it's a good fit:** Massive wildcard API surface across a multi-service platform — great for XSS in merchant UIs, SQLi in search/filter endpoints, broken access control on driver/merchant management. Policy explicitly allows security tools as long as they tag traffic with a unique identifier. Indonesian company.
- **Stats:** 12 scopes, 683 reports submitted, <1 day first-response time. Last updated May 2026.
- **Warning:** Set a custom request header on all SecBot requests to identify test traffic as required by program policy.

### ✅ mattermost (Bugcrowd) — ~$150–$3,000 est.
- **Company:** Mattermost — open-source team messaging (Node.js + React)
- **Platform:** Bugcrowd — `https://bugcrowd.com/engagements/mattermost-mbb-public`
- **Scope:** `mattermost.com`, `*.mattermost.com` (cloud-hosted); also Boards, Copilot, Teams Meeting plugins
- **Why it's a good fit:** Moved from HackerOne to Bugcrowd in November 2024 with expanded scope. Good surface for XSS in message rendering, CORS on API, CSRF on channel/user management, broken access control on admin endpoints. Plugin scope (Copilot, Boards) is newly added and likely less tested.
- **Warning:** Target the cloud-hosted service at `mattermost.com`, not self-hosted instances. Public payout history on HackerOne was low (many low-severity reports) — focus on high/critical in the plugin scopes.

---

## Unchanged targets
- **kredivo** (RedStorm) — confirmed still active; no scope changes found
- **anytask** (Bugcrowd) — confirmed still active
- **moneybird** (HackerOne) — confirmed still active

---
_Generated by [Claude Code](https://claude.ai/code/session_011fnUiEwVetQ6vgTV6PJde4)_