### PR TITLE
chore: update hunt registry — bounty scout [2026-08-03]

### DIFF
--- a/hunt-registry.yaml
+++ b/hunt-registry.yaml
@@ -1,7 +1,9 @@
-# SecBot Hunt Registry — Diagnostic Run #1
+# SecBot Hunt Registry
 # Created: 2026-03-22
-# Purpose: First real bounty hunt — 5 carefully selected targets
+# Updated: 2026-08-03 — Bounty Scout (quarterly refresh)
 # Strategy: low competition + web app depth + SecBot strengths
+
+# ── Active targets ────────────────────────────────────────────────────────────
 
 - name: kredivo
   platform: other
@@ -24,16 +26,39 @@
   schedule: weekly
   enabled: true
 
+# Added 2026-08-03: food-delivery super-app, rich Tier-1 auth + merchant scope
+# Intigriti + HackerOne dual program; automated testing allowed at 3 req/sec
+- name: wolt
+  platform: intigriti
+  scope_file: scopes/wolt.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+# Added 2026-08-03: managed WordPress hosting SaaS, broad wildcard Tier-2 scope
+# Intigriti; automated testing allowed at 3 req/sec; €250–€2,500 Tier-1
+- name: wpengine
+  platform: intigriti
+  scope_file: scopes/wpengine.txt
+  profile: stealth
+  schedule: weekly
+  enabled: true
+
+# ── Disabled targets ──────────────────────────────────────────────────────────
+
+# Disabled 2026-08-03: EC-sponsored program ended June 2026; YesWeHack page returns 404
 - name: openproject
   platform: other
   scope_file: scopes/openproject.txt
   profile: stealth
   schedule: weekly
-  enabled: true
+  enabled: false
 
+# Disabled 2026-08-03: No formal paid bounty found — uses GitHub Security Advisories only.
+# XSS and CSRF explicitly out of scope. Not a good SecBot target.
 - name: calcom
   platform: hackerone
   scope_file: scopes/calcom.txt
   profile: stealth
   schedule: weekly
-  enabled: true
+  enabled: false

--- a/scopes/wolt.txt
+++ b/scopes/wolt.txt
@@ -1,0 +1,34 @@
+# Program: Wolt
+# Platform: Intigriti (https://app.intigriti.com/programs/wolt/wolt/detail)
+# Also on: HackerOne (https://hackerone.com/wolt)
+# Bounty: Tier 1 €150–€3,500 | Tier 2 €100–€2,500
+# Notes: Food delivery platform (now part of DoorDash). Rich scope includes auth portal,
+#        merchant dashboard, corporate portal, ops tools, restaurant API. Automated
+#        testing explicitly allowed at max 3 req/sec. Add header X-Intigriti:<username>.
+#        Test account required for consumer/merchant testing — request from program.
+#        SecBot fit: XSS, CORS, CSRF, IDOR, SQLi, JWT, auth bypass, host-header, SSRF.
+
+In Scope
+# Tier 1 (highest bounty)
+authentication.wolt.com
+corporate.wolt.com
+drive.wolt.com
+merchant.wolt.com
+ops.wolt.com
+restaurant-api.wolt.com
+wolt.com
+
+# Tier 2
+*.wolt.com
+
+Out of Scope
+- Missing security headers or cookie flags (low impact)
+- Low-impact CORS misconfigurations (non-sensitive endpoints)
+- Unauthenticated rate-limit bypass
+- Self-XSS
+- Clickjacking without proven impact
+- Social engineering
+- Payment processor infrastructure (3rd party)
+- Automated scanner results without manual verification proof
+- Mass disclosure of customer/courier/merchant data during testing
+- Using accounts or data you don't own

--- a/scopes/wolt.txt
+++ b/scopes/wolt.txt
@@ -22,13 +22,13 @@ wolt.com
 *.wolt.com
 
 Out of Scope
-- Missing security headers or cookie flags (low impact)
-- Low-impact CORS misconfigurations (non-sensitive endpoints)
-- Unauthenticated rate-limit bypass
-- Self-XSS
-- Clickjacking without proven impact
-- Social engineering
-- Payment processor infrastructure (3rd party)
-- Automated scanner results without manual verification proof
-- Mass disclosure of customer/courier/merchant data during testing
-- Using accounts or data you don't own
+# (no out-of-scope domain/URL patterns — Wolt excludes vulnerability *classes*, not hosts)
+# Excluded by program policy (document only — not hostname patterns):
+# - Missing security headers or cookie flags (low impact)
+# - Low-impact CORS misconfigurations (non-sensitive endpoints)
+# - Unauthenticated rate-limit bypass
+# - Self-XSS
+# - Clickjacking without proven impact
+# - Social engineering, DoS
+# - Payment processor infrastructure (3rd party)
+# - Automated scanner results without manual verification proof

--- a/scopes/wpengine.txt
+++ b/scopes/wpengine.txt
@@ -1,0 +1,43 @@
+# Program: WP Engine
+# Platform: Intigriti (https://app.intigriti.com/programs/wpengine/wpenginebugbounty/detail)
+# Bounty: Tier 1 €250–€2,500 | Tier 2 €125–€1,500 | Tier 3 €50–€1,250
+# Notes: WordPress managed hosting SaaS (~1,100 employees). Rich Tier 1 scope includes
+#        customer portal (my.wpengine.com), billing (payments.wpengine.com), and main site.
+#        Automated testing allowed at max 3 req/sec. Add header User-Agent: Intigriti-<username>.
+#        Broad Tier 2 wildcard scope covers Flywheel, NitroPack, LocalWP, ACF plugins.
+#        SecBot fit: XSS, CSRF, IDOR (multi-tenant portal), SQLi, auth bypass, broken access
+#        control, JWT, host-header, info-disclosure, SSRF, CORS.
+
+In Scope
+# Tier 1 (highest bounty)
+my.wpengine.com
+payments.wpengine.com
+wpengine.com
+app.getflywheel.com
+getflywheel.com
+
+# Tier 2 (wildcards and plugins)
+*.advancedcustomfields.com
+*.localwp.com
+*.nitropack.io
+*.studiopress.com
+*.wpengine.io
+*.wpesvc.net
+
+# Tier 3 (lower bounty)
+makeshift.film
+studiopress.blog
+torquemag.io
+
+Out of Scope
+- Missing security headers (CSP, HSTS, X-Frame-Options)
+- CORS misconfigurations on non-sensitive endpoints
+- Self-XSS
+- Clickjacking without impact
+- Username enumeration without business impact
+- DoS/DDoS attacks
+- Theoretical vulnerabilities without working PoC
+- Brute force attacks
+- WP Engine customer server instances and their hosted applications
+- Staging and non-production environments
+- Social engineering and phishing

--- a/scopes/wpengine.txt
+++ b/scopes/wpengine.txt
@@ -30,14 +30,16 @@ studiopress.blog
 torquemag.io
 
 Out of Scope
-- Missing security headers (CSP, HSTS, X-Frame-Options)
-- CORS misconfigurations on non-sensitive endpoints
-- Self-XSS
-- Clickjacking without impact
-- Username enumeration without business impact
-- DoS/DDoS attacks
-- Theoretical vulnerabilities without working PoC
-- Brute force attacks
-- WP Engine customer server instances and their hosted applications
-- Staging and non-production environments
-- Social engineering and phishing
+# (no out-of-scope domain/URL patterns — WP Engine excludes vulnerability *classes*, not hosts)
+# Customer-hosted apps are out of scope by definition (different operators, not WP Engine infra).
+# Excluded by program policy (document only — not hostname patterns):
+# - Missing security headers (CSP, HSTS, X-Frame-Options)
+# - CORS misconfigurations on non-sensitive endpoints
+# - Self-XSS
+# - Clickjacking without impact
+# - Username enumeration without business impact
+# - DoS/DDoS attacks
+# - Theoretical vulnerabilities without working PoC
+# - Brute force attacks
+# - Staging and non-production environments
+# - Social engineering and phishing


### PR DESCRIPTION
## Summary

Quarterly bounty scout refresh. 2 new targets added, 2 existing targets disabled after scope/status changes discovered.

---

## New Targets

### 🟢 Wolt — Intigriti
- **Program:** https://app.intigriti.com/programs/wolt/wolt/detail (also on HackerOne)
- **Bounty:** Tier 1 €150–€3,500 · Tier 2 €100–€2,500
- **Scope file:** `scopes/wolt.txt`
- **Why it's a good fit:**
  - Rich Tier-1 scope: `authentication.wolt.com`, `merchant.wolt.com`, `corporate.wolt.com`, `drive.wolt.com`, `ops.wolt.com`, `restaurant-api.wolt.com`, `wolt.com`
  - Wildcard Tier-2: `*.wolt.com`
  - Automated testing **explicitly allowed** at max 3 req/sec (add `X-Intigriti:<username>` header)
  - Complex multi-tenant auth flows, merchant dashboards, and partner APIs → ideal surface for SecBot's XSS, IDOR, CORS, CSRF, SQLi, host-header, and auth-bypass checks
  - Lower competition on Intigriti vs HackerOne for the same program
- **Warnings:**
  - Company is now part of DoorDash (~6,000 employees total) — larger than ideal target size, but Intigriti program has lower researcher density
  - Test accounts (consumer + merchant) must be requested from the program before testing merchant-specific flows
  - Missing security headers and low-impact CORS are explicitly out of scope

---

### 🟢 WP Engine — Intigriti
- **Program:** https://app.intigriti.com/programs/wpengine/wpenginebugbounty/detail
- **Bounty:** Tier 1 €250–€2,500 · Tier 2 €125–€1,500 · Tier 3 €50–€1,250
- **Scope file:** `scopes/wpengine.txt`
- **Why it's a good fit:**
  - Tier-1 scope includes customer portal (`my.wpengine.com`), billing portal (`payments.wpengine.com`), and main site — great attack surface for IDOR, broken access control, CSRF, XSS
  - Broad Tier-2 wildcards: Flywheel, NitroPack, LocalWP, ACF, StudioPress plugins
  - Automated testing **explicitly allowed** at max 3 req/sec (add `User-Agent: Intigriti-<username>` header)
  - Managed WordPress hosting → multi-tenant architecture with customer isolation boundaries = high-value IDOR/BAC targets
  - SecBot strengths apply: IDOR, auth bypass, JWT, host-header, SSRF, CORS, SQLi, info-disclosure
- **Warnings:**
  - ~1,100 employees (slightly above 500-employee sweet spot), but good program quality and Intigriti has less noise than HackerOne
  - Customer-hosted server instances and their apps are explicitly out of scope
  - Theoretical vulnerabilities without working PoC are rejected

---

## Disabled Targets

### 🔴 OpenProject — ENDED
- **Reason:** The EC (European Commission)-sponsored bug bounty program on YesWeHack **ended June 2026**. The YesWeHack program URL returns 404. No replacement program has been announced.
- **Action:** Set `enabled: false` in registry.

### 🔴 Cal.com — No formal paid bounty
- **Reason:** Research found no evidence of a paid bug bounty program. Cal.com uses **GitHub Security Advisories** for vulnerability disclosure only. Their security page explicitly lists XSS and CSRF as **out of scope** — which are two of SecBot's core strengths. No formal platform (HackerOne/Bugcrowd/Intigriti) program with bounty tiers found.
- **Action:** Set `enabled: false` in registry.

---

## Unchanged Targets

| Target | Status | Notes |
|--------|--------|-------|
| kredivo | ✅ Active | RedStorm program still running |
| anytask | ✅ Active | Bugcrowd program still active (URL confirmed) |
| moneybird | ✅ Active | HackerOne program still active (invite-only, Rails app) |

---

## Scope Changes to Watch

- **Gojek** (HackerOne): Indonesian super-app, $100–$5,000, but "not accepting submissions at this time" as of research date. Flag for next scout run.
- **LINE Security Bug Bounty**: Temporarily suspended since December 2025, and prohibits automated scanning. Skip.

---
_Generated by [Claude Code](https://claude.ai/code/session_0147mVp4NCVkHjZHP4m4WHx8)_